### PR TITLE
Change CI to use system python

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu
+
+echo "install asdf plugins"
+asdf install
+echo "done installing"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 terraform 0.13.7
 shfmt 3.2.0
 shellcheck 0.7.1
-python 3.10.0
+python system


### PR DESCRIPTION
Update `.tool-versions` to use system python

[_Created by Sourcegraph batch change `sourcegraph/use-system-python-in-ci`._](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes/use-system-python-in-ci)