### PR TITLE
unexpose executor HTTP port due to mertics forwarding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,6 @@ module "aws-executor" {
   preemptible_machines                     = var.executor_preemptible_machines
   instance_tag                             = var.executor_instance_tag
   ssh_access_cidr_range                    = var.executor_ssh_access_cidr_range
-  http_access_cidr_range                   = var.executor_http_access_cidr_range
   sourcegraph_external_url                 = var.executor_sourcegraph_external_url
   sourcegraph_executor_proxy_password      = var.executor_sourcegraph_executor_proxy_password
   queue_name                               = var.executor_queue_name

--- a/main.tf
+++ b/main.tf
@@ -7,15 +7,15 @@ module "aws-networking" {
 module "aws-docker-mirror" {
   source = "./modules/docker-mirror"
 
-  vpc_id                 = module.aws-networking.vpc_id
-  subnet_id              = module.aws-networking.subnet_id
-  machine_ami            = var.docker_mirror_machine_ami
-  machine_type           = var.docker_mirror_machine_type
-  boot_disk_size         = var.docker_mirror_boot_disk_size
-  static_ip              = var.docker_mirror_static_ip
-  ssh_access_cidr_range  = var.docker_mirror_ssh_access_cidr_range
-  http_access_cidr_range = var.docker_mirror_http_access_cidr_range
-  instance_tag_prefix    = var.executor_instance_tag
+  vpc_id                  = module.aws-networking.vpc_id
+  subnet_id               = module.aws-networking.subnet_id
+  http_access_cidr_ranges = module.aws-networking.ip_cidr
+  machine_ami             = var.docker_mirror_machine_ami
+  machine_type            = var.docker_mirror_machine_type
+  boot_disk_size          = var.docker_mirror_boot_disk_size
+  static_ip               = var.docker_mirror_static_ip
+  ssh_access_cidr_range   = var.docker_mirror_ssh_access_cidr_range
+  instance_tag_prefix     = var.executor_instance_tag
 }
 
 module "aws-executor" {

--- a/main.tf
+++ b/main.tf
@@ -7,15 +7,15 @@ module "aws-networking" {
 module "aws-docker-mirror" {
   source = "./modules/docker-mirror"
 
-  vpc_id                  = module.aws-networking.vpc_id
-  subnet_id               = module.aws-networking.subnet_id
-  http_access_cidr_ranges = module.aws-networking.ip_cidr
-  machine_ami             = var.docker_mirror_machine_ami
-  machine_type            = var.docker_mirror_machine_type
-  boot_disk_size          = var.docker_mirror_boot_disk_size
-  static_ip               = var.docker_mirror_static_ip
-  ssh_access_cidr_range   = var.docker_mirror_ssh_access_cidr_range
-  instance_tag_prefix     = var.executor_instance_tag
+  vpc_id                 = module.aws-networking.vpc_id
+  subnet_id              = module.aws-networking.subnet_id
+  http_access_cidr_range = module.aws-networking.ip_cidr
+  machine_ami            = var.docker_mirror_machine_ami
+  machine_type           = var.docker_mirror_machine_type
+  boot_disk_size         = var.docker_mirror_boot_disk_size
+  static_ip              = var.docker_mirror_static_ip
+  ssh_access_cidr_range  = var.docker_mirror_ssh_access_cidr_range
+  instance_tag_prefix    = var.executor_instance_tag
 }
 
 module "aws-executor" {

--- a/modules/credentials/README.md
+++ b/modules/credentials/README.md
@@ -1,7 +1,5 @@
 # Credentials module
 
-This module can be optionally used to create the IAM user policies required to configure auto-scaling and observability of [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) in AWS.
+This module can be optionally used to create the IAM user policies required to configure auto-scaling of [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) in AWS.
 
 Auto-scaling requires that the executor compute instances have permissions to emit CloudWatch metrics. As outlined in [how to configure auto scaling](https://docs.sourcegraph.com/admin/deploy_executors#aws), the Sourcegraph `worker` service must set the `EXECUTOR_METRIC_AWS_ACCESS_KEY_ID` and `EXECUTOR_METRIC_AWS_SECRET_ACCESS_KEY` environment variables to be the same as the `metric_writer_access_key_id` and `metric_writer_secret_key` values provided by running this module.
-
-Observability of executor compute resources require that the target Sourcegraph instance's Prometheus have permissions to scrape the executor compute resources. As outlined in [how to configure observability](https://docs.sourcegraph.com/admin/deploy_executors#aws-1), the `instance_scraper_access_key_id` and `instance_scraper_access_secret_key` values provided by running this module must be supplied to the Sourcegraph Prometheus instance.

--- a/modules/credentials/main.tf
+++ b/modules/credentials/main.tf
@@ -29,18 +29,3 @@ EOF
 resource "aws_iam_access_key" "metric_writer" {
   user = aws_iam_user.metric_writer.name
 }
-
-resource "aws_iam_user" "instance_scraper" {
-  name = "${substr(local.prefix, 0, 11)}-instance-scraper"
-}
-
-resource "aws_iam_policy_attachment" "instance_scraper" {
-  name       = "${substr(var.resource_prefix, 0, 11)}InstanceScraper"
-  users      = [aws_iam_user.instance_scraper.name]
-  groups     = ["readonly"]
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
-}
-
-resource "aws_iam_access_key" "instance_scraper" {
-  user = aws_iam_user.instance_scraper.name
-}

--- a/modules/credentials/outputs.tf
+++ b/modules/credentials/outputs.tf
@@ -5,11 +5,3 @@ output "metric_writer_access_key_id" {
 output "metric_writer_secret_key" {
   value = aws_iam_access_key.metric_writer.secret
 }
-
-output "instance_scraper_access_key_id" {
-  value = aws_iam_access_key.instance_scraper.id
-}
-
-output "instance_scraper_access_secret_key" {
-  value = aws_iam_access_key.instance_scraper.secret
-}

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -48,7 +48,7 @@ resource "aws_iam_role_policy_attachment" "ssm" {
   policy_arn = data.aws_iam_policy.ssm.arn
 }
 
-# Allow access to running instances over SSH and on port 9999 to scrape metrics.
+# Allow access to running instances over SSH.
 resource "aws_security_group" "metrics_access" {
   name   = "${var.resource_prefix}SourcegraphExecutorsMetricsAccess"
   vpc_id = var.vpc_id

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -61,16 +61,6 @@ resource "aws_security_group" "metrics_access" {
     to_port     = 22
   }
 
-  # Only allow access from other instances to scrape metrics.
-  # TODO: Restrict this to not be 0.0.0.0/0.
-  ingress {
-    cidr_blocks = [var.http_access_cidr_range]
-    description = "Allow access to scrape metrics"
-    from_port   = 9999
-    protocol    = "TCP"
-    to_port     = 9999
-  }
-
   # Allow all outgoing network traffic.
   egress {
     from_port        = 0

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -61,6 +61,12 @@ variable "ssh_access_cidr_range" {
   description = "CIDR range from where SSH access to the EC2 instances is acceptable."
 }
 
+variable "http_access_cidr_range" {
+  type        = string
+  default     = "0.0.0.0/0"
+  description = "DEPRECATED. This is not used anymore."
+}
+
 variable "sourcegraph_external_url" {
   type        = string
   description = "The externally accessible URL of the target Sourcegraph instance."

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -61,12 +61,6 @@ variable "ssh_access_cidr_range" {
   description = "CIDR range from where SSH access to the EC2 instances is acceptable."
 }
 
-variable "http_access_cidr_range" {
-  type        = string
-  default     = "0.0.0.0/0"
-  description = "CIDR range from where HTTP access to the metrics endpoint is acceptable."
-}
-
 variable "sourcegraph_external_url" {
   type        = string
   description = "The externally accessible URL of the target Sourcegraph instance."

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -6,13 +6,13 @@ locals {
 # We will have a subnet in there, that has an all-destination route to an egress-only
 # internet gateway. That way, we protect from incoming traffic.
 resource "aws_vpc" "default" {
-  cidr_block                       = local.ip_cidr
+  cidr_block                       = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
 }
 
 resource "aws_subnet" "default" {
   vpc_id            = aws_vpc.default.id
-  cidr_block        = "10.0.1.0/24"
+  cidr_block        = local.ip_cidr
   availability_zone = var.availability_zone
 }
 

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -1,8 +1,12 @@
+locals {
+  ip_cidr = "10.0.1.0/24"
+}
+
 # Create a VPC to host the cache and the executors in.
 # We will have a subnet in there, that has an all-destination route to an egress-only
 # internet gateway. That way, we protect from incoming traffic.
 resource "aws_vpc" "default" {
-  cidr_block                       = "10.0.0.0/16"
+  cidr_block                       = local.ip_cidr
   assign_generated_ipv6_cidr_block = true
 }
 
@@ -13,7 +17,7 @@ resource "aws_subnet" "default" {
 }
 
 resource "aws_internet_gateway" "default" {
-  # TODO: Make this an egress-only internet gateway. This will break our current metrics 
+  # TODO: Make this an egress-only internet gateway. This will break our current metrics
   # collection, though.
   vpc_id = aws_vpc.default.id
 }

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -5,3 +5,7 @@ output "vpc_id" {
 output "subnet_id" {
   value = aws_subnet.default.id
 }
+
+output "ip_cidr" {
+  value = local.ip_cidr
+}

--- a/variables.tf
+++ b/variables.tf
@@ -79,12 +79,6 @@ variable "executor_ssh_access_cidr_range" {
   description = "CIDR range from where SSH access to the EC2 instances is acceptable."
 }
 
-variable "executor_http_access_cidr_range" {
-  type        = string
-  default     = "0.0.0.0/0"
-  description = "CIDR range from where HTTP access to the metrics endpoint is acceptable."
-}
-
 variable "executor_sourcegraph_external_url" {
   type        = string
   description = "The externally accessible URL of the target Sourcegraph instance."

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "docker_mirror_ssh_access_cidr_range" {
 variable "docker_mirror_http_access_cidr_range" {
   type        = string
   default     = "10.0.0.0/16"
-  description = "CIDR range from where HTTP access to the Docker registry is acceptable."
+  description = "DEPRECATED. This is not used anymore."
 }
 
 variable "executor_resource_prefix" {
@@ -77,6 +77,12 @@ variable "executor_ssh_access_cidr_range" {
   type        = string
   default     = "0.0.0.0/0"
   description = "CIDR range from where SSH access to the EC2 instances is acceptable."
+}
+
+variable "executor_http_access_cidr_range" {
+  type        = string
+  default     = "0.0.0.0/0"
+  description = "DEPRECATED. This is not used anymore."
 }
 
 variable "executor_sourcegraph_external_url" {


### PR DESCRIPTION
Removes the instance_scraper IAM stuff and the exposed HTTP port for the executor. Registry still has to be investigated into how we're gonna do that

### Test plan

Verify on k8s cluster.