### PR TITLE
Backport NAT to AWS

### DIFF
--- a/.buildkite/terraform-validate.sh
+++ b/.buildkite/terraform-validate.sh
@@ -11,6 +11,7 @@ MODULES=(
   ./modules/credentials
   .
   ./examples/single-executor
+  ./examples/private-single-executor
   ./examples/multiple-executors
 )
 

--- a/examples/private-single-executor/README.md
+++ b/examples/private-single-executor/README.md
@@ -1,0 +1,3 @@
+# Private single executor example
+
+This is a modification of the basic [single executor](../single-executor/) that provisions private VM instead of VM with public interface. Internet connectivity is made possible with enabling Cloud NAT in the [networking](../../modules/networking/) module.

--- a/examples/private-single-executor/main.tf
+++ b/examples/private-single-executor/main.tf
@@ -1,0 +1,18 @@
+locals {
+  region            = "us-west-2"
+  availability_zone = "us-west-2a"
+}
+
+module "executors" {
+  source  = "sourcegraph/executors/aws"
+  version = "3.42.0" # LATEST
+
+  availability_zone                            = local.availability_zone
+  executor_instance_tag                        = "codeintel-prod"
+  executor_sourcegraph_external_url            = "https://sourcegraph.acme.com"
+  executor_sourcegraph_executor_proxy_password = "hunter2"
+  executor_queue_name                          = "codeintel"
+  executor_metrics_environment_label           = "prod"
+  executor_use_firecracker                     = true
+  #   private_networking                           = true
+}

--- a/examples/private-single-executor/providers.tf
+++ b/examples/private-single-executor/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = local.region
+
+  default_tags {
+    tags = {
+      "deployment" = "sourcegraph-executors"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ module "aws-networking" {
   source = "./modules/networking"
 
   availability_zone = var.availability_zone
+  nat               = var.private_networking
 }
 
 module "aws-docker-mirror" {
@@ -16,6 +17,7 @@ module "aws-docker-mirror" {
   static_ip              = var.docker_mirror_static_ip
   ssh_access_cidr_range  = var.docker_mirror_ssh_access_cidr_range
   instance_tag_prefix    = var.executor_instance_tag
+  assign_public_ip       = var.private_networking ? false : true
 }
 
 module "aws-executor" {
@@ -47,4 +49,5 @@ module "aws-executor" {
   metrics_environment_label                = var.executor_metrics_environment_label
   docker_registry_mirror                   = "http://${var.docker_mirror_static_ip}:5000"
   docker_registry_mirror_node_exporter_url = "http://${var.docker_mirror_static_ip}:9999"
+  assign_public_ip                         = var.private_networking ? false : true
 }

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -56,6 +56,8 @@ resource "aws_volume_attachment" "docker-storage" {
 }
 
 resource "aws_eip" "static" {
+  count = var.assign_public_ip ? 1 : 0
+
   vpc                       = true
   associate_with_private_ip = var.static_ip
   network_interface         = aws_network_interface.static.id
@@ -64,8 +66,7 @@ resource "aws_eip" "static" {
 # Always bind the static IP address to a network interface so it's never claimed
 # by another instance.
 resource "aws_network_interface" "static" {
-  private_ips       = [var.static_ip]
-  ipv4_prefix_count = var.assign_public_ip ? 1 : 0
+  private_ips = [var.static_ip]
   # The subnet also defines the AZ of the instance, so no need to specify it again on the instance.
   subnet_id       = var.subnet_id
   security_groups = [aws_security_group.default.id]

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -71,3 +71,9 @@ variable "instance_tag_prefix" {
   type        = string
   description = "A label tag to add to all the machines; can be used for filtering out the right instances in stackdriver monitoring and in Prometheus instance discovery."
 }
+
+variable "assign_public_ip" {
+  type        = bool
+  default     = true
+  description = "If false, no public IP will be associated with the executors."
+}

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -26,7 +26,7 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "instance" {
-  name = "sourcegraph_executors"
+  name = "${local.prefix}_executors"
   role = aws_iam_role.ec2-role.name
 }
 
@@ -100,7 +100,7 @@ resource "aws_launch_template" "executor" {
   name_prefix = "${local.prefix}executor-template-"
 
   network_interfaces {
-    associate_public_ip_address = true
+    associate_public_ip_address = var.assign_public_ip
     subnet_id                   = var.subnet_id
     # Attach security group.
     security_groups = [aws_security_group.metrics_access.id]

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -176,3 +176,9 @@ variable "docker_registry_mirror_node_exporter_url" {
   default     = ""
   description = "A URL to a docker registry mirror node exporter to scrape (optional)"
 }
+
+variable "assign_public_ip" {
+  type        = bool
+  default     = true
+  description = "If false, no public IP will be associated with the executors."
+}

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -4,4 +4,4 @@ This module provides the networking glue between the sibling [executors](https:/
 
 This module is very simple, creating only a network and a subnet by default.
 
-Using the `nat` flag, an optional NAT will be provisioned in the network, too. This can be useful in conjunction with the `assign_public_ip` option of the executors module to create a private network without public IPs.
+Using the `nat` flag, an optional NAT will be provisioned in the network, too. This can be useful in conjunction with the `assign_public_ip` option of the executors and docker-mirror modules to create a private network without public IPs.

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -2,4 +2,6 @@
 
 This module provides the networking glue between the sibling [executors](https://registry.terraform.io/modules/sourcegraph/executors/aws/3.42.0/submodules/executors) and [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/3.42.0/submodules/docker-mirror) modules.
 
-_(There's very little to talk about in here.)_
+This module is very simple, creating only a network and a subnet by default.
+
+Using the `nat` flag, an optional NAT will be provisioned in the network, too. This can be useful in conjunction with the `assign_public_ip` option of the executors module to create a private network without public IPs.

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -1,30 +1,91 @@
 locals {
-  ip_cidr = "10.0.1.0/24"
+  public_ip_cidr = "10.0.0.0/24"
+  ip_cidr        = "10.0.1.0/24"
 }
 
 # Create a VPC to host the cache and the executors in.
-# We will have a subnet in there, that has an all-destination route to an egress-only
-# internet gateway. That way, we protect from incoming traffic.
 resource "aws_vpc" "default" {
   cidr_block                       = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
 }
 
+# TODO: Rename later to "public". We don't do this now, so the docker mirror disks
+# don't get deleted.
 resource "aws_subnet" "default" {
-  vpc_id            = aws_vpc.default.id
-  cidr_block        = local.ip_cidr
-  availability_zone = var.availability_zone
+  vpc_id                  = aws_vpc.default.id
+  cidr_block              = var.nat == true ? local.public_ip_cidr : local.ip_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
 }
 
-resource "aws_internet_gateway" "default" {
-  # TODO: Make this an egress-only internet gateway. This will break our current metrics
-  # collection, though.
+resource "aws_route_table" "public" {
   vpc_id = aws_vpc.default.id
 }
 
-# Allow all instances in the VPC to reach the internet gateway.
-resource "aws_route" "egress" {
-  route_table_id         = aws_vpc.default.default_route_table_id
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.default.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_subnet" "private" {
+  # Only create this resource when NAT is enabled.
+  count = var.nat == true ? 1 : 0
+
+  vpc_id                  = aws_vpc.default.id
+  cidr_block              = local.ip_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = false
+}
+
+resource "aws_route_table" "private" {
+  # Only create this resource when NAT is enabled.
+  count = var.nat == true ? 1 : 0
+
+  vpc_id = aws_vpc.default.id
+}
+
+resource "aws_route_table_association" "private" {
+  # Only create this resource when NAT is enabled.
+  count = var.nat == true ? 1 : 0
+
+  subnet_id      = aws_subnet.private.0.id
+  route_table_id = aws_route_table.private.0.id
+}
+
+resource "aws_internet_gateway" "default" {
+  vpc_id = aws_vpc.default.id
+}
+
+# Allow all instances in the public VPC to reach the internet gateway.
+resource "aws_route" "public" {
+  route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.default.id
+}
+
+resource "aws_route" "private" {
+  # Only create this resource when NAT is enabled.
+  count = var.nat == true ? 1 : 0
+
+  route_table_id         = aws_route_table.private.0.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.default.0.id
+}
+
+# If NAT mode is enabled, we want a static IP for it.
+resource "aws_eip" "nat" {
+  # Only create this resource when NAT is enabled.
+  count = var.nat ? 1 : 0
+
+  vpc        = true
+  depends_on = [aws_internet_gateway.default]
+}
+
+resource "aws_nat_gateway" "default" {
+  # Only create this resource when NAT is enabled.
+  count = var.nat ? 1 : 0
+
+  allocation_id = aws_eip.nat.0.id
+  subnet_id     = aws_subnet.default.id
+  depends_on    = [aws_internet_gateway.default]
 }

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -3,9 +3,13 @@ output "vpc_id" {
 }
 
 output "subnet_id" {
-  value = aws_subnet.default.id
+  value = var.nat == true ? aws_subnet.private.0.id : aws_subnet.default.id
 }
 
 output "ip_cidr" {
   value = local.ip_cidr
+}
+
+output "nat_ip" {
+  value = var.nat == true ? [aws_eip.nat.0.public_ip] : []
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -1,4 +1,10 @@
 variable "availability_zone" {
   type        = string
-  description = "The availability zone to create the instance in."
+  description = "The availability zone to create the network in."
+}
+
+variable "nat" {
+  type        = bool
+  default     = false
+  description = "When true, the network will contain a NAT router. Use when executors should not get public IPs."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -182,3 +182,9 @@ variable "executor_metrics_environment_label" {
   type        = string
   description = "The value for environment by which to filter the custom metrics."
 }
+
+variable "private_networking" {
+  type        = bool
+  default     = false
+  description = "If true, the executors and docker mirror will live in a private subnet and communicate with the internet through NAT."
+}


### PR DESCRIPTION
Google PR: https://github.com/sourcegraph/terraform-google-executors/pull/54 This is a feature we added for google executors, so for feature parity I'm backporting it.

### Test plan

Tested on k8s cluster.