### PR TITLE
AWS Provider 4.0 Upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ This repository provides a [Terraform module](https://learn.hashicorp.com/tutori
 This repository provides four submodules:
 
 1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0/submodules/executors) provisions compute resources for executors.
-1. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
-1. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
-1. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
+2. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
+3. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
+4. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
 
 The [multiple-executors example](https://github.com/sourcegraph/terraform-aws-executors/blob/v4.1.0/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
 
 1. Provisioning executors for use with multiple features (e.g., both [auto-indexing](https://docs.sourcegraph.com/code_intelligence/explanations/auto_indexing) and [server-side batch changes](https://docs.sourcegraph.com/batch_changes/explanations/server_side)), or
-1. Provisioning resources for multiple Sourcegraph instances (e.g., test, prod)
+2. Provisioning resources for multiple Sourcegraph instances (e.g., test, prod)
 
 This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/aws/4.1.0) combining the executors, network, and docker-mirror resources into an easier to use package.
 
@@ -22,8 +22,12 @@ The [single-executor example](https://github.com/sourcegraph/terraform-aws-execu
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/) ~> 1.1.0
-- [hashicorp/aws](https://registry.terraform.io/providers/hashicorp/aws/3.0.0) ~> 3.0.0
+- [Terraform](https://www.terraform.io/) 
+  - 4.1.0 and below: `~> 1.1.0`
+  - 4.2.0 and above: `>= 1.1.0, < 2.0.0`
+- [hashicorp/aws](https://registry.terraform.io/providers/hashicorp/aws) 
+  - 4.1.0 and below: `~> 3.0.0`
+  - 4.2.0 and above: `>= 3.0, ~> 4.0`
 
 ## Setup
 
@@ -36,7 +40,7 @@ The **major** and **minor** versions both need to match the Sourcegraph version 
 For example:
 
 | **Sourcegraph version** | **Terraform module version** |
-| ----------------------- | ---------------------------- |
+|-------------------------|------------------------------|
 | 3.37.0                  | 3.37.\*                      |
 | 3.37.3                  | 3.37.\*                      |
 | 3.38.0                  | 3.38.\*                      |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The [single-executor example](https://github.com/sourcegraph/terraform-aws-execu
   - 4.2.0 and above: `>= 1.1.0, < 2.0.0`
 - [hashicorp/aws](https://registry.terraform.io/providers/hashicorp/aws) 
   - 4.1.0 and below: `~> 3.0.0`
-  - 4.2.0 and above: `>= 3.0, ~> 4.0`
+  - 4.2.0 and above: `>= 3.0, < 5.0.0`
 
 ## Setup
 

--- a/modules/credentials/providers.tf
+++ b/modules/credentials/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 4.0"
+    aws = "~> 3.0, ~> 4.0"
   }
 }

--- a/modules/credentials/providers.tf
+++ b/modules/credentials/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0, ~> 4.0"
+    aws = ">= 3.0, ~> 4.0"
   }
 }

--- a/modules/credentials/providers.tf
+++ b/modules/credentials/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/modules/credentials/providers.tf
+++ b/modules/credentials/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, ~> 4.0"
+    aws = ">= 3.0, < 5.0.0"
   }
 }

--- a/modules/credentials/providers.tf
+++ b/modules/credentials/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
     aws = ">= 3.0, ~> 4.0"
   }

--- a/modules/credentials/variables.tf
+++ b/modules/credentials/variables.tf
@@ -1,8 +1,3 @@
-variable "availability_zone" {
-  type        = string
-  description = "The availability zone to create the instance in."
-}
-
 variable "resource_prefix" {
   type        = string
   default     = ""

--- a/modules/docker-mirror/providers.tf
+++ b/modules/docker-mirror/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 4.0"
+    aws = "~> 3.0, ~> 4.0"
   }
 }

--- a/modules/docker-mirror/providers.tf
+++ b/modules/docker-mirror/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0, ~> 4.0"
+    aws = ">= 3.0, ~> 4.0"
   }
 }

--- a/modules/docker-mirror/providers.tf
+++ b/modules/docker-mirror/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/modules/docker-mirror/providers.tf
+++ b/modules/docker-mirror/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, ~> 4.0"
+    aws = ">= 3.0, < 5.0.0"
   }
 }

--- a/modules/docker-mirror/providers.tf
+++ b/modules/docker-mirror/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
     aws = ">= 3.0, ~> 4.0"
   }

--- a/modules/executors/providers.tf
+++ b/modules/executors/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 4.0"
+    aws = "~> 3.0, ~> 4.0"
   }
 }

--- a/modules/executors/providers.tf
+++ b/modules/executors/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0, ~> 4.0"
+    aws = ">= 3.0, ~> 4.0"
   }
 }

--- a/modules/executors/providers.tf
+++ b/modules/executors/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/modules/executors/providers.tf
+++ b/modules/executors/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, ~> 4.0"
+    aws = ">= 3.0, < 5.0.0"
   }
 }

--- a/modules/executors/providers.tf
+++ b/modules/executors/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
     aws = ">= 3.0, ~> 4.0"
   }

--- a/modules/networking/providers.tf
+++ b/modules/networking/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 4.0"
+    aws = "~> 3.0, ~> 4.0"
   }
 }

--- a/modules/networking/providers.tf
+++ b/modules/networking/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0, ~> 4.0"
+    aws = ">= 3.0, ~> 4.0"
   }
 }

--- a/modules/networking/providers.tf
+++ b/modules/networking/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 4.0"
   }
 }

--- a/modules/networking/providers.tf
+++ b/modules/networking/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, ~> 4.0"
+    aws = ">= 3.0, < 5.0.0"
   }
 }

--- a/modules/networking/providers.tf
+++ b/modules/networking/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
     aws = ">= 3.0, ~> 4.0"
   }

--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0, ~> 4.0"
+    aws = ">= 3.0, ~> 4.0"
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, ~> 4.0"
+    aws = ">= 3.0, < 5.0.0"
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
     aws = ">= 3.0, ~> 4.0"
   }

--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 1.1.0"
   required_providers {
-    aws = "~> 3.0"
+    aws = "~> 3.0, ~> 4.0"
   }
 }


### PR DESCRIPTION
Closes [#43709](https://github.com/sourcegraph/sourcegraph/issues/43709).

Upgraded AWS providers from `3.0` to `4.0`.

Consulted [Version 4 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade) and there were no impacts.

### Test plan

Tested by deploying to AWS with AWS Module `v4.39.0` and Terraform `1.3.4`