### PR TITLE
Allow a custom security to be used instead of creating the default groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ The [single-executor example](https://github.com/sourcegraph/terraform-aws-execu
 Please follow our [setup guide](https://docs.sourcegraph.com/admin/deploy_executors_terraform) on how to deploy
 executors using Terraform.
 
+### Custom Security Group
+
+By default, the Terraform module will create two security groups. One for the Docker Mirror and the other for 
+the Launch Template. To provide a custom security group instead, set the variable `security_group_id` with 
+the ID of the security group.
+
+If a custom security group is provided, the following rules need to be set
+
+* Allows ingress access on the specified SSH CIDR range (defaults to `10.0.0.0/16`)
+* Allows ingress access to the Docker Registry on the specified HTTP CIDR range (defaults to `10.0.0.0/16`)
+* Allows all outgoing network traffic
+
 ## Compatibility with Sourcegraph
 
 The **major** and **minor** versions both need to match the Sourcegraph version the executors are talking to. Patch version **don't** need to match and it's generally advised to use the latest available.

--- a/main.tf
+++ b/main.tf
@@ -8,16 +8,17 @@ module "aws-networking" {
 module "aws-docker-mirror" {
   source = "./modules/docker-mirror"
 
-  vpc_id                 = module.aws-networking.vpc_id
-  subnet_id              = module.aws-networking.subnet_id
-  http_access_cidr_range = module.aws-networking.ip_cidr
-  machine_ami            = var.docker_mirror_machine_ami
-  machine_type           = var.docker_mirror_machine_type
-  boot_disk_size         = var.docker_mirror_boot_disk_size
-  static_ip              = var.docker_mirror_static_ip
-  ssh_access_cidr_range  = var.docker_mirror_ssh_access_cidr_range
-  instance_tag_prefix    = var.executor_instance_tag
-  assign_public_ip       = var.private_networking ? false : true
+  vpc_id                                 = module.aws-networking.vpc_id
+  subnet_id                              = module.aws-networking.subnet_id
+  http_access_cidr_range                 = module.aws-networking.ip_cidr
+  machine_ami                            = var.docker_mirror_machine_ami
+  machine_type                           = var.docker_mirror_machine_type
+  boot_disk_size                         = var.docker_mirror_boot_disk_size
+  static_ip                              = var.docker_mirror_static_ip
+  ssh_access_cidr_range                  = var.docker_mirror_ssh_access_cidr_range
+  instance_tag_prefix                    = var.executor_instance_tag
+  assign_public_ip                       = var.private_networking ? false : true
+  docker_mirror_access_security_group_id = var.security_group_id
 }
 
 module "aws-executor" {
@@ -50,4 +51,5 @@ module "aws-executor" {
   docker_registry_mirror                   = "http://${var.docker_mirror_static_ip}:5000"
   docker_registry_mirror_node_exporter_url = "http://${var.docker_mirror_static_ip}:9999"
   assign_public_ip                         = var.private_networking ? false : true
+  metrics_access_security_group_id         = var.security_group_id
 }

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -90,13 +90,15 @@ resource "aws_network_interface" "static" {
   private_ips = [var.static_ip]
   # The subnet also defines the AZ of the instance, so no need to specify it again on the instance.
   subnet_id       = var.subnet_id
-  security_groups = [aws_security_group.default.id]
+  security_groups = [var.docker_mirror_access_security_group_id != "" ? var.docker_mirror_access_security_group_id : aws_security_group.default[0].id]
 }
 
 resource "aws_security_group" "default" {
   name        = "SourcegraphExecutorsDockerMirrorAccess"
   description = "Security group used by Sourcegraph executors to define access to the docker registry mirror."
   vpc_id      = var.vpc_id
+  # If a security group has already been provided, no need to create this security group
+  count = var.docker_mirror_access_security_group_id == "" ? 1 : 0
 
   ingress {
     cidr_blocks = [var.ssh_access_cidr_range]

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -77,3 +77,9 @@ variable "assign_public_ip" {
   default     = true
   description = "If false, no public IP will be associated with the executors."
 }
+
+variable "docker_mirror_access_security_group_id" {
+  type        = string
+  default     = ""
+  description = "If provided, the default security groups will not be created. The ID of the security group to associate the Docker Mirror network with."
+}

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -52,6 +52,8 @@ resource "aws_iam_role_policy_attachment" "ssm" {
 resource "aws_security_group" "metrics_access" {
   name   = "${var.resource_prefix}SourcegraphExecutorsMetricsAccess"
   vpc_id = var.vpc_id
+  # If a security group has already been provided, no need to create this security group
+  count = var.metrics_access_security_group_id == "" ? 1 : 0
 
   ingress {
     cidr_blocks = [var.ssh_access_cidr_range]
@@ -124,7 +126,7 @@ resource "aws_launch_template" "executor" {
     associate_public_ip_address = var.assign_public_ip
     subnet_id                   = var.subnet_id
     # Attach security group.
-    security_groups = [aws_security_group.metrics_access.id]
+    security_groups = [var.metrics_access_security_group_id != "" ? var.metrics_access_security_group_id : aws_security_group.metrics_access[0].id]
   }
 
   monitoring {

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -182,3 +182,9 @@ variable "assign_public_ip" {
   default     = true
   description = "If false, no public IP will be associated with the executors."
 }
+
+variable "metrics_access_security_group_id" {
+  type        = string
+  default     = ""
+  description = "If provided, the default security groups will not be created. The ID of the security group to associate the Launch Template network with."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -188,3 +188,9 @@ variable "private_networking" {
   default     = false
   description = "If true, the executors and docker mirror will live in a private subnet and communicate with the internet through NAT."
 }
+
+variable "security_group_id" {
+  type        = string
+  default     = ""
+  description = "If provided, the default security groups will not be created. The ID of the security group to associate the Docker Mirror network and the Launch Template network with."
+}


### PR DESCRIPTION
Closes [#43950](https://github.com/sourcegraph/sourcegraph/issues/43950).

Allow a custom security group id to be provided instead of creating the default groups.

### Test plan

Tested locally.
