### PR TITLE
Mark secret variables `sensitive`

### DIFF
--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -75,6 +75,7 @@ variable "sourcegraph_external_url" {
 variable "sourcegraph_executor_proxy_password" {
   type        = string
   description = "The shared password used to authenticate requests to the internal executor proxy."
+  sensitive   = true
 }
 
 variable "queue_name" {
@@ -193,4 +194,5 @@ variable "docker_auth_config" {
   type        = string
   default     = ""
   description = "If provided, this docker auth config file will be used to authorize image pulls. See [Using private registries](https://docs.sourcegraph.com/admin/deploy_executors#using-private-registries) for how to configure."
+  sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,7 @@ variable "executor_sourcegraph_external_url" {
 variable "executor_sourcegraph_executor_proxy_password" {
   type        = string
   description = "The shared password used to authenticate requests to the internal executor proxy."
+  sensitive   = true
 }
 
 variable "executor_queue_name" {
@@ -199,4 +200,5 @@ variable "executor_docker_auth_config" {
   type        = string
   default     = ""
   description = "If provided, this docker auth config file will be used to authorize image pulls. See [Using private registries](https://docs.sourcegraph.com/admin/deploy_executors#using-private-registries) for how to configure."
+  sensitive   = true
 }


### PR DESCRIPTION
I noticed that these password/authentication variables were not marked `sensitive` to protect them from being output into logs and console output.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->

- Ensure that `sensitive` is spelled right.
- Run automated tests to ensure terraform plan/apply can be run with this code.