### PR TITLE
add EXECUTOR_DOCKER_AUTH_CONFIG to executor.env

### DIFF
--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 ## Pull terraform variables into the environment.
 %{ for key, value in environment_variables }
-${key}="${value}"
+${key}="${replace(value, "\"", "\\\\\\\"")}"
 %{ endfor ~}
 
 # Conditionally set below
@@ -41,6 +41,7 @@ EXECUTOR_NUM_TOTAL_JOBS="$${EXECUTOR_NUM_TOTAL_JOBS}"
 EXECUTOR_MAX_ACTIVE_TIME="$${EXECUTOR_MAX_ACTIVE_TIME}"
 EXECUTOR_USE_FIRECRACKER="$${EXECUTOR_USE_FIRECRACKER}"
 EXECUTOR_DOCKER_REGISTRY_MIRROR_URL="$${EXECUTOR_DOCKER_REGISTRY_MIRROR}"
+EXECUTOR_DOCKER_AUTH_CONFIG="$${EXECUTOR_DOCKER_AUTH_CONFIG}"
 $${DOCKER_REGISTRY_NODE_EXPORTER_URL_LINE}
 EOF
 


### PR DESCRIPTION
## Explanation

This is a weird one, so I will try to explain. In https://github.com/sourcegraph/terraform-aws-executors/pull/57 support for passing in the docker auth config was added, but I believe one step was missed: adding to to the step at the bottom of the startup script to write it to the `/etc/systemd/system/executor.env` which seems to be where the executor pulls its env vars from.

However, in debugging this I found some more problems with this, centering around shell script syntax and escaping.

I tested by sending a json encoded string into the module, something like:

```hcl
module "executors-codeintel" {
  source  = "sourcegraph/executors/aws//modules/executors"
  version = "4.4.1"
  [...]
  docker_auth_config = jsonencode({ 
    "auths" = {
      "my.registry:443" = {
        "auth" = base64encode("${data.aws_ssm_parameter.user.value}:${data.aws_ssm_parameter.pass.value}")
      }
    }
  })
}
```

However, that resulted in the following:

#### With no escaping

init-script (`/var/lib/cloud/instance/scripts/part-001`)
```
EXECUTOR_DOCKER_AUTH_CONFIG="{"auths":{"my.registry:443":{"auth":"REDACTED"}}}"
```

^ That's "valid" bash because of the way quotes work. But in ends up with the quotes removed:

`/etc/systemd/system/executor.env`
```
EXECUTOR_DOCKER_AUTH_CONFIG="{auths:{my.registry:443:{auth:REDACTED}}}"
```

So I escaped the quotes in the `.tpl` template...

#### With single escaping

init-script (`/var/lib/cloud/instance/scripts/part-001`)
```
EXECUTOR_DOCKER_AUTH_CONFIG="{\"auths\":{\"my.registry:443\":{\"auth\":\"REDACTED\"}}}"
```

^ That worked in the init script, but then below it gets re-interpolated, which ends up with the same weird bash quotes issue:

`/etc/systemd/system/executor.env`
```
EXECUTOR_DOCKER_AUTH_CONFIG="{"auths":{"my.registry:443":{"auth":"REDACTED"}}}"
```

So I realized we need to double escape it, which results in the following (correct) result:

#### With double escaping

init-script (`/var/lib/cloud/instance/scripts/part-001`)
```
EXECUTOR_DOCKER_AUTH_CONFIG="{\\\"auths\\\":{\\\"my.registry:443\\\":{\\\"auth\\\":\\\"REDACTED\\\"}}}"
```

`/etc/systemd/system/executor.env`
```
EXECUTOR_DOCKER_AUTH_CONFIG="{\"auths\":{\"my.registry:443\":{\"auth\":\"REDACTED\"}}}"
```

However, in order to get the double-escaping to work in the template file, within another set of double-quotes, I had to triple escape (!) the value. So we end up with 7 backslashes (!).

I would certainly be open to other ways of fixing this but I can't think of something a lot simpler. Putting json inside shell env vars is just bound to be weird, I guess.

---

## Side note:

I also noticed/figured out that because of how this startup script is written, the port on the docker registry is _required_. The script crashes half way through if you don't provide a port. We might want to fix that, or at least document it.

### Test plan

I tested this with our sonatype nexus docker registry.
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
