### PR TITLE
chore: change default of `disk_iops` for executors and docker-mirror to 3000

### DIFF
--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -34,7 +34,7 @@ variable "disk_size" {
 
 variable "disk_iops" {
   type        = number
-  default     = 500
+  default     = 3000
   description = "Persistent Docker registry mirror additional IOPS."
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -34,7 +34,7 @@ variable "boot_disk_size" {
 
 variable "boot_disk_iops" {
   type        = number
-  default     = 500
+  default     = 3000
   description = "Executor node disk additional IOPS."
 }
 


### PR DESCRIPTION
The disk type `gp3` comes with a [minimum of 3000 IOPS](https://aws.amazon.com/ebs/general-purpose/), so any subsequent apply will try and change it back to 500, which is an operation that can only be performed once every 6 hours.

Also introduces a root module variable to optionally change these values for the `executors` and `docker-mirror` submodules.

### Test plan
None

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
