### PR TITLE
AWS executor Terraform template updates

### DIFF
--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -169,6 +169,8 @@ resource "aws_launch_template" "executor" {
 
   update_default_version = true
 
+  key_name = var.key_name
+
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -196,3 +196,10 @@ variable "docker_auth_config" {
   description = "If provided, this docker auth config file will be used to authorize image pulls. See [Using private registries](https://docs.sourcegraph.com/admin/deploy_executors#using-private-registries) for how to configure."
   sensitive   = true
 }
+
+variable "key_name" {
+  type        = string
+  default     = ""
+  description = "If provided, this value will be used to define an existing EC2 ssh key pair to user with the executor instance."
+  sensitive   = true
+}

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -1,5 +1,5 @@
 output "vpc_id" {
-  value       = aws_vpc.default.id
+  value       = var.create_vpc == true ? aws_vpc.default.id : data.aws_vpc.existing.id
   description = "The ID of the VPC that hosts the cache and the executors in."
 }
 

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -8,3 +8,14 @@ variable "nat" {
   default     = false
   description = "When true, the network will contain a NAT router. Use when executors should not get public IPs."
 }
+
+variable "create_vpc" {
+  type        = bool
+  default     = true
+  description = "When true, a dedicated VPC will be created for deploying all executors resources into"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "AWS identifier of existing VPC to deploy into when create_vpc is set to false"
+}


### PR DESCRIPTION
Introducing a couple of changes to our AWS terraform scripts requested after a PoC evaluation of Sourcegraph:

1. "By default, it will create a default VPC to put the executors in.  We wanted it in our own VPC. So it would be great if users had an option to ignore this or set the VPC to create the executors in."
2. "For the executors, give the ability for users to assign a key_name in the aws_launch_template for SSH access to the executors.  This is very helpful when troubleshooting issues on the executor."

A third requested for adding `instance_refresh` configuration to the ASG would conflict with the existing `launch_instance` config (see notes [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group#instance_refresh)). I'm not sure if there is another way this could be accomplished.

3. "For the executors, if the launch template, user data, etc changes, we noticed that we had to manually terminate the current executor so it could spin up a new one with the new configurations.  We’ve used the instance_refresh option in our Terraform on ASG’s to help automate this."

### Test plan

TODO
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
