### PR TITLE
Refactor: optionally randomize resource names

### DIFF
--- a/examples/multiple-executors/main.tf
+++ b/examples/multiple-executors/main.tf
@@ -8,19 +8,21 @@ module "networking" {
   source  = "sourcegraph/executors/aws//modules/networking"
   version = "4.5.0" # LATEST
 
-  availability_zone        = local.availability_zone
-  randomize_resource_names = true
+  availability_zone = local.availability_zone
+  # TODO uncomment when cutting release
+  #  randomize_resource_names = true
 }
 
 module "docker-mirror" {
   source  = "sourcegraph/executors/aws//modules/docker-mirror"
   version = "4.5.0" # LATEST
 
-  vpc_id                   = module.networking.vpc_id
-  subnet_id                = module.networking.subnet_id
-  static_ip                = local.docker_mirror_static_ip
-  instance_tag_prefix      = "prod"
-  randomize_resource_names = true
+  vpc_id              = module.networking.vpc_id
+  subnet_id           = module.networking.subnet_id
+  static_ip           = local.docker_mirror_static_ip
+  instance_tag_prefix = "prod"
+  # TODO uncomment when cutting release
+  #  randomize_resource_names = true
 }
 
 module "executors-codeintel" {
@@ -37,8 +39,9 @@ module "executors-codeintel" {
   metrics_environment_label           = "prod"
   docker_registry_mirror              = "http://${local.docker_mirror_static_ip}:5000"
   #   docker_registry_mirror_node_exporter_url = "http://${local.docker_mirror_static_ip}:9999"
-  use_firecracker          = true
-  randomize_resource_names = true
+  use_firecracker = true
+  # TODO uncomment when cutting release
+  #  randomize_resource_names = true
 }
 
 module "executors-batches" {
@@ -55,6 +58,7 @@ module "executors-batches" {
   metrics_environment_label           = "prod"
   docker_registry_mirror              = "http://${local.docker_mirror_static_ip}:5000"
   #   docker_registry_mirror_node_exporter_url = "http://${local.docker_mirror_static_ip}:9999"
-  use_firecracker          = true
-  randomize_resource_names = true
+  use_firecracker = true
+  # TODO uncomment when cutting release
+  #  randomize_resource_names = true
 }

--- a/examples/multiple-executors/main.tf
+++ b/examples/multiple-executors/main.tf
@@ -37,8 +37,8 @@ module "executors-codeintel" {
   metrics_environment_label           = "prod"
   docker_registry_mirror              = "http://${local.docker_mirror_static_ip}:5000"
   #   docker_registry_mirror_node_exporter_url = "http://${local.docker_mirror_static_ip}:9999"
-  use_firecracker                     = true
-  randomize_resource_names            = true
+  use_firecracker          = true
+  randomize_resource_names = true
 }
 
 module "executors-batches" {
@@ -55,6 +55,6 @@ module "executors-batches" {
   metrics_environment_label           = "prod"
   docker_registry_mirror              = "http://${local.docker_mirror_static_ip}:5000"
   #   docker_registry_mirror_node_exporter_url = "http://${local.docker_mirror_static_ip}:9999"
-  use_firecracker                     = true
-  randomize_resource_names            = true
+  use_firecracker          = true
+  randomize_resource_names = true
 }

--- a/examples/multiple-executors/main.tf
+++ b/examples/multiple-executors/main.tf
@@ -8,17 +8,19 @@ module "networking" {
   source  = "sourcegraph/executors/aws//modules/networking"
   version = "4.5.0" # LATEST
 
-  availability_zone = local.availability_zone
+  availability_zone        = local.availability_zone
+  randomize_resource_names = true
 }
 
 module "docker-mirror" {
   source  = "sourcegraph/executors/aws//modules/docker-mirror"
   version = "4.5.0" # LATEST
 
-  vpc_id              = module.networking.vpc_id
-  subnet_id           = module.networking.subnet_id
-  static_ip           = local.docker_mirror_static_ip
-  instance_tag_prefix = "prod"
+  vpc_id                   = module.networking.vpc_id
+  subnet_id                = module.networking.subnet_id
+  static_ip                = local.docker_mirror_static_ip
+  instance_tag_prefix      = "prod"
+  randomize_resource_names = true
 }
 
 module "executors-codeintel" {
@@ -35,7 +37,8 @@ module "executors-codeintel" {
   metrics_environment_label           = "prod"
   docker_registry_mirror              = "http://${local.docker_mirror_static_ip}:5000"
   #   docker_registry_mirror_node_exporter_url = "http://${local.docker_mirror_static_ip}:9999"
-  use_firecracker = true
+  use_firecracker                     = true
+  randomize_resource_names            = true
 }
 
 module "executors-batches" {
@@ -52,5 +55,6 @@ module "executors-batches" {
   metrics_environment_label           = "prod"
   docker_registry_mirror              = "http://${local.docker_mirror_static_ip}:5000"
   #   docker_registry_mirror_node_exporter_url = "http://${local.docker_mirror_static_ip}:9999"
-  use_firecracker = true
+  use_firecracker                     = true
+  randomize_resource_names            = true
 }

--- a/examples/multiple-executors/providers.tf
+++ b/examples/multiple-executors/providers.tf
@@ -3,9 +3,9 @@ provider "aws" {
 
   default_tags {
     tags = {
-      "Name" = null
+      "Name"         = null
       "executor_tag" = null
-      "deployment" = "sourcegraph-executors"
+      "deployment"   = "sourcegraph-executors"
     }
   }
 }

--- a/examples/multiple-executors/providers.tf
+++ b/examples/multiple-executors/providers.tf
@@ -3,6 +3,8 @@ provider "aws" {
 
   default_tags {
     tags = {
+      "Name" = null
+      "executor_tag" = null
       "deployment" = "sourcegraph-executors"
     }
   }

--- a/examples/private-single-executor/main.tf
+++ b/examples/private-single-executor/main.tf
@@ -14,5 +14,6 @@ module "executors" {
   executor_queue_name                          = "codeintel"
   executor_metrics_environment_label           = "prod"
   executor_use_firecracker                     = true
+  randomize_resource_names                     = true
   #   private_networking                           = true
 }

--- a/examples/private-single-executor/main.tf
+++ b/examples/private-single-executor/main.tf
@@ -14,6 +14,7 @@ module "executors" {
   executor_queue_name                          = "codeintel"
   executor_metrics_environment_label           = "prod"
   executor_use_firecracker                     = true
-  randomize_resource_names                     = true
+  # TODO uncomment when cutting release
+  #  randomize_resource_names                     = true
   #   private_networking                           = true
 }

--- a/examples/private-single-executor/providers.tf
+++ b/examples/private-single-executor/providers.tf
@@ -3,9 +3,9 @@ provider "aws" {
 
   default_tags {
     tags = {
-      "Name" = null
+      "Name"         = null
       "executor_tag" = null
-      "deployment" = "sourcegraph-executors"
+      "deployment"   = "sourcegraph-executors"
     }
   }
 }

--- a/examples/private-single-executor/providers.tf
+++ b/examples/private-single-executor/providers.tf
@@ -3,6 +3,8 @@ provider "aws" {
 
   default_tags {
     tags = {
+      "Name" = null
+      "executor_tag" = null
       "deployment" = "sourcegraph-executors"
     }
   }

--- a/examples/single-executor/main.tf
+++ b/examples/single-executor/main.tf
@@ -14,5 +14,6 @@ module "executors" {
   executor_queue_name                          = "codeintel"
   executor_metrics_environment_label           = "prod"
   executor_use_firecracker                     = true
-  randomize_resource_names                     = true
+  # TODO uncomment when cutting release
+  #  randomize_resource_names                     = true
 }

--- a/examples/single-executor/main.tf
+++ b/examples/single-executor/main.tf
@@ -14,4 +14,5 @@ module "executors" {
   executor_queue_name                          = "codeintel"
   executor_metrics_environment_label           = "prod"
   executor_use_firecracker                     = true
+  randomize_resource_names                     = true
 }

--- a/examples/single-executor/providers.tf
+++ b/examples/single-executor/providers.tf
@@ -3,9 +3,9 @@ provider "aws" {
 
   default_tags {
     tags = {
-      "Name" = null
+      "Name"         = null
       "executor_tag" = null
-      "deployment" = "sourcegraph-executors"
+      "deployment"   = "sourcegraph-executors"
     }
   }
 }

--- a/examples/single-executor/providers.tf
+++ b/examples/single-executor/providers.tf
@@ -3,6 +3,8 @@ provider "aws" {
 
   default_tags {
     tags = {
+      "Name" = null
+      "executor_tag" = null
       "deployment" = "sourcegraph-executors"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,6 @@ module "aws-docker-mirror" {
   instance_tag_prefix                    = var.executor_instance_tag
   assign_public_ip                       = var.private_networking ? false : true
   docker_mirror_access_security_group_id = var.security_group_id
-  disk_iops                              = 3000
 }
 
 module "aws-executor" {

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ module "aws-networking" {
   source = "./modules/networking"
 
   randomize_resource_names = var.randomize_resource_names
+  resource_prefix          = var.executor_resource_prefix
   availability_zone        = var.availability_zone
   nat                      = var.private_networking
 }
@@ -9,6 +10,8 @@ module "aws-networking" {
 module "aws-docker-mirror" {
   source = "./modules/docker-mirror"
 
+  randomize_resource_names               = var.randomize_resource_names
+  resource_prefix                        = var.executor_resource_prefix
   vpc_id                                 = module.aws-networking.vpc_id
   subnet_id                              = module.aws-networking.subnet_id
   http_access_cidr_range                 = module.aws-networking.ip_cidr
@@ -26,9 +29,10 @@ module "aws-docker-mirror" {
 module "aws-executor" {
   source = "./modules/executors"
 
+  randomize_resource_names                 = var.randomize_resource_names
+  resource_prefix                          = var.executor_resource_prefix
   vpc_id                                   = module.aws-networking.vpc_id
   subnet_id                                = module.aws-networking.subnet_id
-  resource_prefix                          = var.executor_resource_prefix
   machine_image                            = var.executor_machine_image
   machine_type                             = var.executor_machine_type
   boot_disk_size                           = var.executor_boot_disk_size

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 module "aws-networking" {
   source = "./modules/networking"
 
-  availability_zone = var.availability_zone
-  nat               = var.private_networking
+  randomize_resource_names = var.randomize_resource_names
+  availability_zone        = var.availability_zone
+  nat                      = var.private_networking
 }
 
 module "aws-docker-mirror" {
@@ -19,6 +20,7 @@ module "aws-docker-mirror" {
   instance_tag_prefix                    = var.executor_instance_tag
   assign_public_ip                       = var.private_networking ? false : true
   docker_mirror_access_security_group_id = var.security_group_id
+  disk_iops                              = 3000
 }
 
 module "aws-executor" {

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -92,5 +92,5 @@ variable "resource_prefix" {
 
 variable "randomize_resource_names" {
   type        = bool
-  description = "TODO"
+  description = "Use randomized names for resources. Deployments using the legacy naming convention will be updated in-place with randomized names when enabled."
 }

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -83,3 +83,14 @@ variable "docker_mirror_access_security_group_id" {
   default     = ""
   description = "If provided, the default security groups will not be created. The ID of the security group to associate the Docker Mirror network with."
 }
+
+variable "resource_prefix" {
+  type        = string
+  default     = ""
+  description = "An optional prefix to add to all resources created."
+}
+
+variable "randomize_resource_names" {
+  type        = bool
+  description = "TODO"
+}

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -2,6 +2,38 @@ locals {
   autoscaling        = var.min_replicas != var.max_replicas
   prefix             = var.resource_prefix != "" ? "${var.resource_prefix}_sourcegraph_" : "sourcegraph_"
   scaling_expression = "CEIL(queueSize / ${var.jobs_per_instance_scaling}) - instanceCount"
+
+  security_group = {
+    name = var.randomize_resource_names ? "${local.prefix}executors-${random_id.security_group[0].hex}" : "${var.resource_prefix}SourcegraphExecutorsMetricsAccess"
+  }
+  cloudwatch_log_group = {
+    name = var.randomize_resource_names ? "${local.prefix}executors-${random_id.cloudwatch_log_group[0].hex}" : null
+  }
+  iam_instance_profile = {
+    name = var.randomize_resource_names ? "${local.prefix}executors-${random_id.iam_instance_profile[0].hex}" : "${local.prefix}_executors"
+  }
+  launch_template = {
+    name = var.randomize_resource_names ? "${local.prefix}executors-${random_id.launch_template[0].hex}" : null
+  }
+  autoscaling_group = {
+    name = var.randomize_resource_names && local.autoscaling ? "${local.prefix}executors-${random_id.autoscaling_group[0].hex}" : "${local.prefix}executors"
+  }
+  cloudwatch_metric_alarm = {
+    in = {
+      name = var.randomize_resource_names && local.autoscaling ? "${local.prefix}executors-${random_id.cloudwatch_metric_alarm_in[0].hex}" : "${local.prefix}executor_queue_scale_in_trigger"
+    }
+    out = {
+      name = var.randomize_resource_names && local.autoscaling ? "${local.prefix}executors-${random_id.cloudwatch_metric_alarm_out[0].hex}" : "${local.prefix}executor_queue_scale_out_trigger"
+    }
+  }
+  autoscaling_policy = {
+    out = {
+      name = var.randomize_resource_names && local.autoscaling ? "${local.prefix}executors-${random_id.autoscaling_policy_out[0].hex}" : "${local.prefix}executor_queue_scale_out"
+    }
+    in = {
+      name = var.randomize_resource_names && local.autoscaling ? "${local.prefix}executors-${random_id.autoscaling_policy_in[0].hex}" : "${local.prefix}executor_queue_scale_in"
+    }
+  }
 }
 
 resource "aws_iam_role" "ec2-role" {
@@ -25,9 +57,18 @@ resource "aws_iam_role" "ec2-role" {
 EOF
 }
 
+resource "random_id" "iam_instance_profile" {
+  count       = var.randomize_resource_names ? 1 : 0
+  byte_length = 6
+}
+
 resource "aws_iam_instance_profile" "instance" {
-  name = "${local.prefix}_executors"
+  name = local.iam_instance_profile.name
   role = aws_iam_role.ec2-role.name
+
+  tags = {
+    Name = local.iam_instance_profile.name
+  }
 }
 
 data "aws_iam_policy" "cloudwatch" {
@@ -48,12 +89,17 @@ resource "aws_iam_role_policy_attachment" "ssm" {
   policy_arn = data.aws_iam_policy.ssm.arn
 }
 
+resource "random_id" "security_group" {
+  count       = var.randomize_resource_names ? 1 : 0
+  byte_length = 6
+}
+
 # Allow access to running instances over SSH.
 resource "aws_security_group" "metrics_access" {
-  name   = "${var.resource_prefix}SourcegraphExecutorsMetricsAccess"
+  name   = local.security_group.name
   vpc_id = var.vpc_id
   # If a security group has already been provided, no need to create this security group
-  count = var.metrics_access_security_group_id == "" ? 1 : 0
+  count  = var.metrics_access_security_group_id == "" ? 1 : 0
 
   ingress {
     cidr_blocks = [var.ssh_access_cidr_range]
@@ -71,12 +117,25 @@ resource "aws_security_group" "metrics_access" {
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
+
+  tags = {
+    Name = local.security_group.name
+  }
+}
+
+resource "random_id" "cloudwatch_log_group" {
+  count       = var.randomize_resource_names ? 1 : 0
+  byte_length = 6
 }
 
 resource "aws_cloudwatch_log_group" "syslogs" {
   # TODO: This is hardcoded in the executor image.
   name              = "executors"
   retention_in_days = 7
+
+  tags = {
+    Name = local.cloudwatch_log_group.name
+  }
 }
 
 data "aws_ami" "latest_ami" {
@@ -98,6 +157,11 @@ data "aws_ami" "latest_ami" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+}
+
+resource "random_id" "launch_template" {
+  count       = var.randomize_resource_names ? 1 : 0
+  byte_length = 6
 }
 
 # Template for the instances launched by the autoscaling group.
@@ -126,7 +190,7 @@ resource "aws_launch_template" "executor" {
     associate_public_ip_address = var.assign_public_ip
     subnet_id                   = var.subnet_id
     # Attach security group.
-    security_groups = [var.metrics_access_security_group_id != "" ? var.metrics_access_security_group_id : aws_security_group.metrics_access[0].id]
+    security_groups             = [var.metrics_access_security_group_id != "" ? var.metrics_access_security_group_id : aws_security_group.metrics_access[0].id]
   }
 
   monitoring {
@@ -172,15 +236,32 @@ resource "aws_launch_template" "executor" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = {
+      Name = local.launch_template.name
+    }
+  }
+
+  tags = {
+    Name = local.launch_template.name
+  }
+}
+
+resource "random_id" "autoscaling_group" {
+  count       = var.randomize_resource_names ? 1 : 0
+  byte_length = 6
 }
 
 resource "aws_autoscaling_group" "autoscaler" {
-  name                      = "${local.prefix}executors"
+  name                      = local.autoscaling_group.name
   min_size                  = var.min_replicas
   max_size                  = var.max_replicas
   vpc_zone_identifier       = [var.subnet_id]
   health_check_grace_period = 300
-  enabled_metrics = [
+  enabled_metrics           = [
     "GroupDesiredCapacity",
     "GroupInServiceCapacity",
     "GroupPendingCapacity",
@@ -205,7 +286,7 @@ resource "aws_autoscaling_group" "autoscaler" {
 
   tag {
     key                 = "name"
-    value               = "sourcegraph_executor"
+    value               = local.autoscaling_group.name
     propagate_at_launch = true
   }
 
@@ -215,11 +296,16 @@ resource "aws_autoscaling_group" "autoscaler" {
   }
 }
 
+resource "random_id" "cloudwatch_metric_alarm_out" {
+  count       = local.autoscaling && var.randomize_resource_names ? 1 : 0
+  byte_length = 6
+}
+
 resource "aws_cloudwatch_metric_alarm" "scale_out_alarm" {
   # Don't create this resource when autoscaling is disabled.
   count = local.autoscaling ? 1 : 0
 
-  alarm_name                = "${local.prefix}executor_queue_scale_out_trigger"
+  alarm_name                = local.cloudwatch_metric_alarm.out.name
   comparison_operator       = "GreaterThanThreshold"
   threshold                 = "0"
   evaluation_periods        = "1"
@@ -254,7 +340,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_out_alarm" {
       stat        = "Maximum"
 
       dimensions = {
-        "AutoScalingGroupName" = "${local.prefix}executors"
+        "AutoScalingGroupName" = local.autoscaling_group.name
       }
     }
   }
@@ -266,23 +352,37 @@ resource "aws_cloudwatch_metric_alarm" "scale_out_alarm" {
     label       = "The target number of instances to add to efficiently process the queue at its current size."
     return_data = "true"
   }
+
+  tags = {
+    Name = local.cloudwatch_metric_alarm.out.name
+  }
+}
+
+resource "random_id" "autoscaling_policy_out" {
+  count       = local.autoscaling && var.randomize_resource_names ? 1 : 0
+  byte_length = 6
 }
 
 resource "aws_autoscaling_policy" "scale_out" {
   # Don't create this resource when autoscaling is disabled.
   count = local.autoscaling ? 1 : 0
 
-  name                   = "${local.prefix}executor_queue_scale_out"
+  name                   = local.autoscaling_policy.out.name
   autoscaling_group_name = aws_autoscaling_group.autoscaler.name
   adjustment_type        = "ChangeInCapacity"
   scaling_adjustment     = 1
+}
+
+resource "random_id" "cloudwatch_metric_alarm_in" {
+  count       = local.autoscaling && var.randomize_resource_names ? 1 : 0
+  byte_length = 6
 }
 
 resource "aws_cloudwatch_metric_alarm" "scale_in_alarm" {
   # Don't create this resource when autoscaling is disabled.
   count = local.autoscaling ? 1 : 0
 
-  alarm_name                = "${local.prefix}executor_queue_scale_in_trigger"
+  alarm_name                = local.cloudwatch_metric_alarm.in.name
   comparison_operator       = "LessThanThreshold"
   threshold                 = "0"
   evaluation_periods        = "1"
@@ -317,7 +417,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_in_alarm" {
       stat        = "Maximum"
 
       dimensions = {
-        "AutoScalingGroupName" = "${local.prefix}executors"
+        "AutoScalingGroupName" = local.autoscaling_group.name
       }
     }
   }
@@ -329,13 +429,22 @@ resource "aws_cloudwatch_metric_alarm" "scale_in_alarm" {
     label       = "The target number of instances that can be removed and continue to efficiently process the queue at its current size."
     return_data = "true"
   }
+
+  tags = {
+    Name = local.cloudwatch_metric_alarm.in.name
+  }
+}
+
+resource "random_id" "autoscaling_policy_in" {
+  count       = local.autoscaling && var.randomize_resource_names ? 1 : 0
+  byte_length = 6
 }
 
 resource "aws_autoscaling_policy" "scale_in" {
   # Don't create this resource when autoscaling is disabled.
   count = local.autoscaling ? 1 : 0
 
-  name                   = "${local.prefix}executor_queue_scale_in"
+  name                   = local.autoscaling_policy.in.name
   autoscaling_group_name = aws_autoscaling_group.autoscaler.name
   adjustment_type        = "ChangeInCapacity"
   scaling_adjustment     = -1

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -99,7 +99,7 @@ resource "aws_security_group" "metrics_access" {
   name   = local.security_group.name
   vpc_id = var.vpc_id
   # If a security group has already been provided, no need to create this security group
-  count  = var.metrics_access_security_group_id == "" ? 1 : 0
+  count = var.metrics_access_security_group_id == "" ? 1 : 0
 
   ingress {
     cidr_blocks = [var.ssh_access_cidr_range]
@@ -190,7 +190,7 @@ resource "aws_launch_template" "executor" {
     associate_public_ip_address = var.assign_public_ip
     subnet_id                   = var.subnet_id
     # Attach security group.
-    security_groups             = [var.metrics_access_security_group_id != "" ? var.metrics_access_security_group_id : aws_security_group.metrics_access[0].id]
+    security_groups = [var.metrics_access_security_group_id != "" ? var.metrics_access_security_group_id : aws_security_group.metrics_access[0].id]
   }
 
   monitoring {
@@ -261,7 +261,7 @@ resource "aws_autoscaling_group" "autoscaler" {
   max_size                  = var.max_replicas
   vpc_zone_identifier       = [var.subnet_id]
   health_check_grace_period = 300
-  enabled_metrics           = [
+  enabled_metrics = [
     "GroupDesiredCapacity",
     "GroupInServiceCapacity",
     "GroupPendingCapacity",

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -199,5 +199,5 @@ variable "docker_auth_config" {
 
 variable "randomize_resource_names" {
   type        = bool
-  description = "TODO"
+  description = "Use randomized names for resources. Deployments using the legacy naming convention will be updated in-place with randomized names when enabled."
 }

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -196,3 +196,8 @@ variable "docker_auth_config" {
   description = "If provided, this docker auth config file will be used to authorize image pulls. See [Using private registries](https://docs.sourcegraph.com/admin/deploy_executors#using-private-registries) for how to configure."
   sensitive   = true
 }
+
+variable "randomize_resource_names" {
+  type        = bool
+  description = "TODO"
+}

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -2,36 +2,40 @@ locals {
   public_ip_cidr = "10.0.0.0/24"
   ip_cidr        = "10.0.1.0/24"
 
+  resource_prefix = (var.resource_prefix == "" || substr(var.resource_prefix, -1, -2) == "-") ? var.resource_prefix : "${var.resource_prefix}-"
+
   vpc = {
-    name = var.randomize_resource_names ? "${random_id.vpc[0].hex}-executors" : null
+    name = var.randomize_resource_names ? "${local.resource_prefix}executors-${random_id.vpc[0].hex}" : null
   }
   subnet = {
     public = {
-      name = var.randomize_resource_names ? "${random_id.subnet_public[0].hex}-executors-public" : null
+      name = var.randomize_resource_names ? "${local.resource_prefix}executors-public-${random_id.subnet_public[0].hex}" : null
     }
     private = {
-      name = var.randomize_resource_names ? "${random_id.subnet_private[0].hex}-executors-private" : null
+      name = var.randomize_resource_names ? "${local.resource_prefix}executors-private-${random_id.subnet_private[0].hex}" : null
     }
   }
   route_table = {
     public = {
-      name = var.randomize_resource_names ? "${random_id.route_table_public[0].hex}-executors-public" : null
+      name = var.randomize_resource_names ? "${local.resource_prefix}executors-public-${random_id.route_table_public[0].hex}" : null
     }
     private = {
-      name = var.randomize_resource_names ? "${random_id.route_table_private[0].hex}-executors-public" : null
+      name = var.randomize_resource_names ? "${local.resource_prefix}executors-public-${random_id.route_table_private[0].hex}" : null
     }
   }
   internet_gateway = {
-    name = var.randomize_resource_names ? "${random_id.internet_gateway[0].hex}-executors-public" : null
+    name = var.randomize_resource_names ? "${local.resource_prefix}executors-public-${random_id.internet_gateway[0].hex}" : null
   }
   eip = {
-    name = var.randomize_resource_names ? "${random_id.eip[0].hex}-executors" : null
+    name = var.randomize_resource_names ? "${local.resource_prefix}executors-${random_id.eip[0].hex}" : null
+  }
+  nat_gateway = {
+    name = var.randomize_resource_names ? "${local.resource_prefix}executors-${random_id.eip[0].hex}" : null
   }
 }
 
 resource "random_id" "vpc" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -47,7 +51,6 @@ resource "aws_vpc" "default" {
 
 resource "random_id" "subnet_public" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -66,7 +69,6 @@ resource "aws_subnet" "default" {
 
 resource "random_id" "route_table_public" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -85,7 +87,6 @@ resource "aws_route_table_association" "public" {
 
 resource "random_id" "subnet_private" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -101,7 +102,6 @@ resource "aws_subnet" "private" {
 
 resource "random_id" "route_table_private" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -126,7 +126,6 @@ resource "aws_route_table_association" "private" {
 
 resource "random_id" "internet_gateway" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -156,7 +155,6 @@ resource "aws_route" "private" {
 
 resource "random_id" "eip" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -175,7 +173,6 @@ resource "aws_eip" "nat" {
 
 resource "random_id" "nat_gateway" {
   count       = var.randomize_resource_names ? 1 : 0
-  prefix      = var.resource_prefix
   byte_length = 6
 }
 
@@ -188,6 +185,6 @@ resource "aws_nat_gateway" "default" {
   depends_on    = [aws_internet_gateway.default]
 
   tags = {
-    Name = local.nat_gae
+    Name = local.nat_gateway.name
   }
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -17,5 +17,5 @@ variable "resource_prefix" {
 
 variable "randomize_resource_names" {
   type        = bool
-  description = "TODO"
+  description = "Use randomized names for resources. Deployments using the legacy naming convention will be updated in-place with randomized names when enabled."
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -8,3 +8,14 @@ variable "nat" {
   default     = false
   description = "When true, the network will contain a NAT router. Use when executors should not get public IPs."
 }
+
+variable "resource_prefix" {
+    type        = string
+    default     = ""
+    description = "An optional prefix to add to all resources created."
+}
+
+variable "randomize_resource_names" {
+    type        = bool
+    description = "TODO"
+}

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -10,12 +10,12 @@ variable "nat" {
 }
 
 variable "resource_prefix" {
-    type        = string
-    default     = ""
-    description = "An optional prefix to add to all resources created."
+  type        = string
+  default     = ""
+  description = "An optional prefix to add to all resources created."
 }
 
 variable "randomize_resource_names" {
-    type        = bool
-    description = "TODO"
+  type        = bool
+  description = "TODO"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -217,5 +217,6 @@ variable "executor_docker_auth_config" {
 
 variable "randomize_resource_names" {
   type        = bool
-  description = "TODO"
+  default     = false
+  description = "Use randomized names for resources. Deployments using the legacy naming convention will be updated in-place with randomized names when enabled."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -214,3 +214,8 @@ variable "executor_docker_auth_config" {
   description = "If provided, this docker auth config file will be used to authorize image pulls. See [Using private registries](https://docs.sourcegraph.com/admin/deploy_executors#using-private-registries) for how to configure."
   sensitive   = true
 }
+
+variable "randomize_resource_names" {
+  type        = bool
+  description = "TODO"
+}


### PR DESCRIPTION
- Part of https://github.com/sourcegraph/sourcegraph/issues/44239

Adds a `randomize_resource_names` variable that allows random resource names to be generated.  
This is less critical than its GCP counterpart due to the fact that AWS already generates random IDs, but for organizing resources it is still valuable to set resource names.

Due to a [bug in the AWS provider](https://github.com/hashicorp/terraform-provider-aws/issues/19583) running `terraform apply` twice would be needed to set the calculated tags. To circumvent this, the `default_tags` block in the provider config sets `null` for these tags:

```terraform
default_tags {
  tags = {
    "Name"         = null
    "executor_tag" = null
    "deployment"   = "sourcegraph-executors"
  }
}
```

### Test plan
Tested on scaletesting instance.

The following plan is produced when planning these changes on an existing deployment using v4.5.0 of the module with `randomize_resource_names = false`. There are some tags that are added because they have defaults added now, but those don't have functional impacts. The `name` tag for `aws_autoscaling_group.autoscaler` is updated from `sourcegraph_executor` to `sourcegraph_executors` to align with other naming conventions.

```shell
Terraform will perform the following actions:

  # module.executors.module.aws-docker-mirror.aws_security_group.default[0] will be updated in-place
  ~ resource "aws_security_group" "default" {
        id                     = "sg-0c3a16702f8ae3721"
        name                   = "SourcegraphExecutorsDockerMirrorAccess"
      ~ tags                   = {
          + "Name" = "SourcegraphExecutorsDockerMirrorAccess"
        }
      ~ tags_all               = {
          + "Name"       = "SourcegraphExecutorsDockerMirrorAccess"
            # (1 unchanged element hidden)
        }
        # (7 unchanged attributes hidden)
    }

  # module.executors.module.aws-executor.aws_autoscaling_group.autoscaler will be updated in-place
  ~ resource "aws_autoscaling_group" "autoscaler" {
        id                        = "sourcegraph_executors"
        name                      = "sourcegraph_executors"
        # (23 unchanged attributes hidden)


      - tag {
          - key                 = "name" -> null
          - propagate_at_launch = true -> null
          - value               = "sourcegraph_executor" -> null
        }
      + tag {
          + key                 = "name"
          + propagate_at_launch = true
          + value               = "sourcegraph_executors"
        }
        # (2 unchanged blocks hidden)
    }

  # module.executors.module.aws-executor.aws_iam_instance_profile.instance will be updated in-place
  ~ resource "aws_iam_instance_profile" "instance" {
        id          = "sourcegraph__executors"
        name        = "sourcegraph__executors"
      ~ tags        = {
          + "Name" = "sourcegraph__executors"
        }
      ~ tags_all    = {
          + "Name"       = "sourcegraph__executors"
            # (1 unchanged element hidden)
        }
        # (5 unchanged attributes hidden)
    }

  # module.executors.module.aws-executor.aws_launch_template.executor will be updated in-place
  ~ resource "aws_launch_template" "executor" {
      ~ default_version                      = 1 -> (known after apply)
        id                                   = "lt-0b1c2bb507662dc30"
      ~ latest_version                       = 1 -> (known after apply)
        name                                 = "sourcegraph_executor-template-20230304103845369900000002"
        tags                                 = {}
        # (17 unchanged attributes hidden)





      + tag_specifications {
          + resource_type = "instance"
        }
        # (4 unchanged blocks hidden)
    }

  # module.executors.module.aws-executor.aws_security_group.metrics_access[0] will be updated in-place
  ~ resource "aws_security_group" "metrics_access" {
        id                     = "sg-03830ca9ad561e223"
        name                   = "SourcegraphExecutorsMetricsAccess"
      ~ tags                   = {
          + "Name" = "SourcegraphExecutorsMetricsAccess"
        }
      ~ tags_all               = {
          + "Name"       = "SourcegraphExecutorsMetricsAccess"
            # (1 unchanged element hidden)
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 5 to change, 0 to destroy.

```

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
