### PR TITLE
add ability to set permissions_boundary (null by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The [single-executor example](https://github.com/sourcegraph/terraform-aws-execu
 
 ## Setup
 
-Please follow our [setup guide](https://docs.sourcegraph.com/admin/deploy_executors_terraform) on how to deploy
+Please follow our [setup guide](https://docs.sourcegraph.com/admin/executors/deploy_executors_terraform) on how to deploy
 executors using Terraform.
 
 ### Custom Security Group

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ module "aws-docker-mirror" {
   instance_tag_prefix                    = var.executor_instance_tag
   assign_public_ip                       = var.private_networking ? false : true
   docker_mirror_access_security_group_id = var.security_group_id
+  permissions_boundary_arn               = var.permissions_boundary_arn
 }
 
 module "aws-executor" {
@@ -58,4 +59,5 @@ module "aws-executor" {
   assign_public_ip                         = var.private_networking ? false : true
   metrics_access_security_group_id         = var.security_group_id
   docker_auth_config                       = var.executor_docker_auth_config
+  permissions_boundary_arn                 = var.permissions_boundary_arn
 }

--- a/modules/credentials/main.tf
+++ b/modules/credentials/main.tf
@@ -4,6 +4,8 @@ locals {
 
 resource "aws_iam_user" "metric_writer" {
   name = "${substr(local.prefix, 0, 14)}-metric-writer"
+
+  permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : ""
 }
 
 resource "aws_iam_user_policy" "metric_writer" {

--- a/modules/credentials/variables.tf
+++ b/modules/credentials/variables.tf
@@ -6,6 +6,6 @@ variable "resource_prefix" {
 
 variable "permissions_boundary_arn" {
   type        = string
-  default     = null
+  default     = ""
   description = "ARN for permissions boundaries on IAM users and roles created by this module"
 }

--- a/modules/credentials/variables.tf
+++ b/modules/credentials/variables.tf
@@ -7,5 +7,5 @@ variable "resource_prefix" {
 variable "permissions_boundary_arn" {
   type        = string
   default     = ""
-  description = "ARN for permissions boundaries on IAM users and roles created by this module"
+  description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }

--- a/modules/credentials/variables.tf
+++ b/modules/credentials/variables.tf
@@ -3,3 +3,9 @@ variable "resource_prefix" {
   default     = ""
   description = "An optional prefix to add to all resources created."
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  default     = null
+  description = "ARN for permissions boundaries on IAM users and roles created by this module"
+}

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -199,6 +199,8 @@ resource "aws_iam_role" "ec2-role" {
   name = "sourcegraph_executors_docker_mirror"
   path = "/"
 
+  permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : ""
+
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -97,6 +97,6 @@ variable "randomize_resource_names" {
 
 variable "permissions_boundary_arn" {
   type        = string
-  default     = null
+  default     = ""
   description = "ARN for permissions boundaries on IAM users and roles created by this module"
 }

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -94,3 +94,9 @@ variable "randomize_resource_names" {
   type        = bool
   description = "Use randomized names for resources. Deployments using the legacy naming convention will be updated in-place with randomized names when enabled."
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  default     = null
+  description = "ARN for permissions boundaries on IAM users and roles created by this module"
+}

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -98,5 +98,5 @@ variable "randomize_resource_names" {
 variable "permissions_boundary_arn" {
   type        = string
   default     = ""
-  description = "ARN for permissions boundaries on IAM users and roles created by this module"
+  description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -40,6 +40,8 @@ resource "aws_iam_role" "ec2-role" {
   name = "${local.prefix}_executors"
   path = "/"
 
+  permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : ""
+
   assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -204,6 +204,6 @@ variable "randomize_resource_names" {
 
 variable "permissions_boundary_arn" {
   type        = string
-  default     = null
+  default     = ""
   description = "ARN for permissions boundaries on IAM users and roles created by this module"
 }

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -201,3 +201,9 @@ variable "randomize_resource_names" {
   type        = bool
   description = "Use randomized names for resources. Deployments using the legacy naming convention will be updated in-place with randomized names when enabled."
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  default     = null
+  description = "ARN for permissions boundaries on IAM users and roles created by this module"
+}

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -205,5 +205,5 @@ variable "randomize_resource_names" {
 variable "permissions_boundary_arn" {
   type        = string
   default     = ""
-  description = "ARN for permissions boundaries on IAM users and roles created by this module"
+  description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -223,6 +223,6 @@ variable "randomize_resource_names" {
 
 variable "permissions_boundary_arn" {
   type        = string
-  default     = null
+  default     = ""
   description = "The ARN of a permissions boundary policy for further security measures on newly created IAM roles and users"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -224,5 +224,5 @@ variable "randomize_resource_names" {
 variable "permissions_boundary_arn" {
   type        = string
   default     = ""
-  description = "The ARN of a permissions boundary policy for further security measures on newly created IAM roles and users"
+  description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -220,3 +220,9 @@ variable "randomize_resource_names" {
   default     = false
   description = "Use randomized names for resources. Deployments using the legacy naming convention will be updated in-place with randomized names when enabled."
 }
+
+variable "permissions_boundary_arn" {
+  type        = string
+  default     = null
+  description = "The ARN of a permissions boundary policy for further security measures on newly created IAM roles and users"
+}


### PR DESCRIPTION
### Test plan

- [X] `terraform plan` with and without the variable set works and would create roles with and without (respectively) the permissions_boundary key set

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
