### PR TITLE
add ability to specify AMI version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ module "aws-docker-mirror" {
   http_access_cidr_range                 = module.aws-networking.ip_cidr
   machine_ami                            = var.docker_mirror_machine_ami
   machine_type                           = var.docker_mirror_machine_type
+  sourcegraph_version                    = var.sourcegraph_version
   boot_disk_size                         = var.docker_mirror_boot_disk_size
   static_ip                              = var.docker_mirror_static_ip
   ssh_access_cidr_range                  = var.docker_mirror_ssh_access_cidr_range
@@ -35,6 +36,7 @@ module "aws-executor" {
   subnet_id                                = module.aws-networking.subnet_id
   machine_image                            = var.executor_machine_image
   machine_type                             = var.executor_machine_type
+  sourcegraph_version                      = var.sourcegraph_version
   boot_disk_size                           = var.executor_boot_disk_size
   preemptible_machines                     = var.executor_preemptible_machines
   instance_tag                             = var.executor_instance_tag

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "aws-docker-mirror" {
   http_access_cidr_range                 = module.aws-networking.ip_cidr
   machine_ami                            = var.docker_mirror_machine_ami
   machine_type                           = var.docker_mirror_machine_type
-  sourcegraph_version                    = var.sourcegraph_version
+  ami_version                            = var.ami_version
   boot_disk_size                         = var.docker_mirror_boot_disk_size
   static_ip                              = var.docker_mirror_static_ip
   ssh_access_cidr_range                  = var.docker_mirror_ssh_access_cidr_range
@@ -36,7 +36,7 @@ module "aws-executor" {
   subnet_id                                = module.aws-networking.subnet_id
   machine_image                            = var.executor_machine_image
   machine_type                             = var.executor_machine_type
-  sourcegraph_version                      = var.sourcegraph_version
+  ami_version                              = var.ami_version
   boot_disk_size                           = var.executor_boot_disk_size
   preemptible_machines                     = var.executor_preemptible_machines
   instance_tag                             = var.executor_instance_tag

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -17,7 +17,7 @@ locals {
     name = var.randomize_resource_names ? "${local.resource_prefix}SourcegraphExecutorsDockerMirrorAccess-${random_id.security_group[0].hex}" : "SourcegraphExecutorsDockerMirrorAccess"
   }
 
-  specified_version = join("-", split(".", replace(var.sourcegraph_version, "v", "")))
+  specified_version = join("-", split(".", replace(var.ami_version, "v", "")))
 }
 
 resource "random_id" "cloudwatch_log_group" {
@@ -63,7 +63,7 @@ data "aws_ami" "latest_ami" {
 }
 
 data "aws_ami" "ami" {
-  count       = var.sourcegraph_version == "" ? 0 : 1
+  count       = var.ami_version == "" ? 0 : 1
   most_recent = true
   owners      = ["185007729374"]
 
@@ -91,7 +91,7 @@ resource "random_id" "instance" {
 # The docker registry mirror EC2 instance.
 resource "aws_instance" "default" {
   # Order of precedence: machine_ami > sourcegraph_version > latest_ami
-  ami           = var.machine_ami != "" ? var.machine_ami : var.sourcegraph_version != "" ? data.aws_ami.ami.0.image_id : data.aws_ami.latest_ami.0.image_id
+  ami           = var.machine_ami != "" ? var.machine_ami : var.ami_version != "" ? data.aws_ami.ami.0.image_id : data.aws_ami.latest_ami.0.image_id
   instance_type = var.machine_type
 
   root_block_device {

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -16,6 +16,8 @@ locals {
   security_group = {
     name = var.randomize_resource_names ? "${local.resource_prefix}SourcegraphExecutorsDockerMirrorAccess-${random_id.security_group[0].hex}" : "SourcegraphExecutorsDockerMirrorAccess"
   }
+
+  specified_version = join("-", split(".", replace(var.sourcegraph_version, "v", "")))
 }
 
 resource "random_id" "cloudwatch_log_group" {
@@ -60,6 +62,27 @@ data "aws_ami" "latest_ami" {
   }
 }
 
+data "aws_ami" "ami" {
+  count       = var.machine_ami != "" ? 0 : 1
+  most_recent = true
+  owners      = ["185007729374"]
+
+  filter {
+    name   = "name"
+    values = ["sourcegraph-executors-docker-mirror-${local.specified_version}"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 resource "random_id" "instance" {
   count       = var.randomize_resource_names ? 1 : 0
   byte_length = 6
@@ -67,7 +90,8 @@ resource "random_id" "instance" {
 
 # The docker registry mirror EC2 instance.
 resource "aws_instance" "default" {
-  ami           = var.machine_ami != "" ? var.machine_ami : data.aws_ami.latest_ami.0.image_id
+  # Order of precedence: machine_ami > sourcegraph_version > latest_ami
+  ami           = var.machine_ami != "" ? var.machine_ami : var.sourcegraph_version != "" ? data.aws_ami.ami.0.image_id : data.aws_ami.latest_ami.0.image_id
   instance_type = var.machine_type
 
   root_block_device {

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -63,7 +63,7 @@ data "aws_ami" "latest_ami" {
 }
 
 data "aws_ami" "ami" {
-  count       = var.machine_ami != "" ? 0 : 1
+  count       = var.sourcegraph_version == "" ? 0 : 1
   most_recent = true
   owners      = ["185007729374"]
 

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -20,14 +20,14 @@ variable "machine_type" {
   description = "Docker registry mirror node machine type."
 }
 
-variable "sourcegraph_version" {
+variable "ami_version" {
   type        = string
   default     = ""
-  description = "Specify a Sourcegraph executor version to use rather than pulling latest"
+  description = "Specify a Sourcegraph executor ami version to use rather than pulling latest"
 
   validation {
-    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.sourcegraph_version))
-    error_message = "The Soucegraph version must be valid semver"
+    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
+    error_message = "The Soucegraph ami version must be valid semver"
   }
 }
 

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -20,6 +20,17 @@ variable "machine_type" {
   description = "Docker registry mirror node machine type."
 }
 
+variable "sourcegraph_version" {
+  type        = string
+  default     = ""
+  description = "Specify a Sourcegraph executor version to use rather than pulling latest"
+
+  validation {
+    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.sourcegraph_version))
+    error_message = "The Soucegraph version must be valid semver"
+  }
+}
+
 variable "boot_disk_size" {
   type        = number
   default     = 32

--- a/modules/docker-mirror/variables.tf
+++ b/modules/docker-mirror/variables.tf
@@ -27,7 +27,7 @@ variable "ami_version" {
 
   validation {
     condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
-    error_message = "The Soucegraph ami version must be valid semver"
+    error_message = "The Soucegraph ami version must be valid semver."
   }
 }
 

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -168,7 +168,7 @@ data "aws_ami" "latest_ami" {
 }
 
 data "aws_ami" "ami" {
-  count       = var.machine_image != "" ? 0 : 1
+  count       = var.sourcegraph_version == "" ? 0 : 1
   most_recent = true
   owners      = ["185007729374"]
 

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -39,7 +39,7 @@ locals {
     }
   }
 
-  specified_version = join("-", split(".", replace(var.sourcegraph_version, "v", "")))
+  specified_version = join("-", split(".", replace(var.ami_version, "v", "")))
 }
 
 resource "aws_iam_role" "ec2-role" {
@@ -168,7 +168,7 @@ data "aws_ami" "latest_ami" {
 }
 
 data "aws_ami" "ami" {
-  count       = var.sourcegraph_version == "" ? 0 : 1
+  count       = var.ami_version == "" ? 0 : 1
   most_recent = true
   owners      = ["185007729374"]
 
@@ -200,8 +200,8 @@ resource "random_id" "launch_template" {
 resource "aws_launch_template" "executor" {
   instance_type = var.machine_type
 
-  # Order of precedence: machine_image > sourcegraph_version > latest_ami
-  image_id = var.machine_image != "" ? var.machine_image : var.sourcegraph_version != "" ? data.aws_ami.ami.0.image_id : data.aws_ami.latest_ami.0.image_id
+  # Order of precedence: machine_image > ami_version > latest_ami
+  image_id = var.machine_image != "" ? var.machine_image : var.ami_version != "" ? data.aws_ami.ami.0.image_id : data.aws_ami.latest_ami.0.image_id
 
   block_device_mappings {
     device_name = "/dev/sda1"

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -33,7 +33,7 @@ variable "ami_version" {
 
   validation {
     condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
-    error_message = "The Soucegraph ami version must be valid semver"
+    error_message = "The Soucegraph ami version must be valid semver."
   }
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -26,14 +26,14 @@ variable "machine_type" {
   description = "Executor node machine type."
 }
 
-variable "sourcegraph_version" {
+variable "ami_version" {
   type        = string
   default     = ""
-  description = "Specify a Sourcegraph executor version to use rather than pulling latest"
+  description = "Specify a Sourcegraph executor ami version to use rather than pulling latest"
 
   validation {
-    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.sourcegraph_version))
-    error_message = "The Soucegraph version must be valid semver"
+    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
+    error_message = "The Soucegraph ami version must be valid semver"
   }
 }
 

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -26,6 +26,17 @@ variable "machine_type" {
   description = "Executor node machine type."
 }
 
+variable "sourcegraph_version" {
+  type        = string
+  default     = ""
+  description = "Specify a Sourcegraph executor version to use rather than pulling latest"
+
+  validation {
+    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.sourcegraph_version))
+    error_message = "The Soucegraph version must be valid semver"
+  }
+}
+
 variable "boot_disk_size" {
   type        = number
   default     = 500

--- a/variables.tf
+++ b/variables.tf
@@ -234,13 +234,13 @@ variable "permissions_boundary_arn" {
   description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }
 
-variable "sourcegraph_version" {
+variable "ami_version" {
   type        = string
   default     = ""
-  description = "Specify a Sourcegraph executor version to use rather than pulling latest"
+  description = "Specify a Sourcegraph executor ami version to use rather than pulling latest"
 
   validation {
-    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.sourcegraph_version))
-    error_message = "The Soucegraph version must be valid semver"
+    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
+    error_message = "The Soucegraph ami version must be valid semver"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -233,3 +233,14 @@ variable "permissions_boundary_arn" {
   default     = ""
   description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }
+
+variable "sourcegraph_version" {
+  type        = string
+  default     = ""
+  description = "Specify a Sourcegraph executor version to use rather than pulling latest"
+
+  validation {
+    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.sourcegraph_version))
+    error_message = "The Soucegraph version must be valid semver"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -241,6 +241,6 @@ variable "ami_version" {
 
   validation {
     condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
-    error_message = "The Soucegraph ami version must be valid semver"
+    error_message = "The Soucegraph ami version must be valid semver."
   }
 }


### PR DESCRIPTION
Add the optional ability to specify an AMI version instead of pulling the latest AMI or specifying an exact AMI ID.

* Add `ami_version` var with some validation.
* Specify precedence of exact AMI ID > AMI version > latest AMI.

### Test plan

Ran `terraform validate` and a `terraform plan -var ami_version=5.2.245428` successfully with the new `ami` data source pulling the proper AMI.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
