### PR TITLE
Mount Private Root CA certificates in Executor hosts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,4 +61,5 @@ module "aws-executor" {
   metrics_access_security_group_id         = var.security_group_id
   docker_auth_config                       = var.executor_docker_auth_config
   permissions_boundary_arn                 = var.permissions_boundary_arn
+  private_ca_cert_path                     = var.private_ca_cert_path
 }

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -38,7 +38,6 @@ locals {
       name = var.randomize_resource_names && local.autoscaling ? "${local.prefix}executors-${random_id.autoscaling_policy_in[0].hex}" : "${local.prefix}executor_queue_scale_in"
     }
   }
-  # private_ca_cert = var.private_ca_cert_path != "" ? file(var.private_ca_cert_path) : ""
 }
 
 resource "aws_iam_role" "ec2-role" {

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -38,6 +38,7 @@ locals {
       name = var.randomize_resource_names && local.autoscaling ? "${local.prefix}executors-${random_id.autoscaling_policy_in[0].hex}" : "${local.prefix}executor_queue_scale_in"
     }
   }
+  # private_ca_cert = var.private_ca_cert_path != "" ? file(var.private_ca_cert_path) : ""
 }
 
 resource "aws_iam_role" "ec2-role" {
@@ -235,6 +236,7 @@ resource "aws_launch_template" "executor" {
       "EXECUTOR_MAX_ACTIVE_TIME"            = var.max_active_time
       "EXECUTOR_USE_FIRECRACKER"            = var.use_firecracker
       "EXECUTOR_DOCKER_AUTH_CONFIG"         = var.docker_auth_config
+      "PRIVATE_CA_CERTIFICATE"              = var.private_ca_cert_path != "" ? file(var.private_ca_cert_path) : ""
     }
   }))
 

--- a/modules/executors/startup-script.sh.tpl
+++ b/modules/executors/startup-script.sh.tpl
@@ -27,6 +27,10 @@ if [ "$${EXECUTOR_DOCKER_REGISTRY_MIRROR}" != '' ]; then
   fi
 fi
 
+if [ "$${PRIVATE_CA_CERTIFICATE}" != '' ]; then
+  echo "$${PRIVATE_CA_CERTIFICATE}" > /etc/ssl/certs/private_ca_cert.pem
+fi
+
 # Write the systemd environment file used by the executor service
 cat <<EOF >/etc/systemd/system/executor.env
 EXECUTOR_QUEUE_NAME="$${EXECUTOR_QUEUE_NAME}"

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -214,3 +214,9 @@ variable "permissions_boundary_arn" {
   default     = ""
   description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }
+
+variable "private_ca_cert_path" {
+  type        = string
+  default     = ""
+  description = "Path to the private CA certificate file"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -233,3 +233,9 @@ variable "permissions_boundary_arn" {
   default     = ""
   description = "If not provided, there will be no permissions boundary on IAM roles and users created. The ARN of a policy to use for permissions boundaries with IAM roles and users."
 }
+
+variable "private_ca_cert_path" {
+  type        = string
+  default     = ""
+  description = "Path to the private CA certificate file"
+}


### PR DESCRIPTION
Added an option for mounting a custom certificate in a Terraform-deployed executor host
