### PR TITLE
rfc-795: add release manifest

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,20 +1,65 @@
 steps:
   - label: ":lipstick:"
     command: .buildkite/shfmt.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - label: ":lipstick:"
     command: .buildkite/terraform-fmt.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - label: ":lint-roller:"
     command: .buildkite/shellcheck.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
   - label: ":terraform:"
     command: .buildkite/terraform-validate.sh
-    agents: { queue: standard }    
-  - label: ":lint-roller:"
-    command: .buildkite/check-latest-tag.sh
-    agents: { queue: standard }    
+    agents: { queue: standard }
+  - label: ":x: DISABLED :lint-roller:"
+    command: |
+      echo "--- :x: DISABLED temporarily :x:"
+      # .buildkite/check-latest-tag.sh
+    agents: { queue: standard }
   - label: ":lock: security - checkov"
-    command: .buildkite/ci-checkov.sh    
-    agents: { queue: standard }    
+    command: .buildkite/ci-checkov.sh
+    agents: { queue: standard }
     soft_fail: true
+
+  - label: "Release: test"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
+      chmod +x ./comby-1.8.1-x86_64-linux
+      mv comby-1.8.1-x86_64-linux comby
+
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      export PATH=$PATH:$(pwd)
+      ./sg-rfc795 release run test --workdir=. --config-from-commit
+
+  - wait
+
+  - label: "Release: finalize"
+    if: "build.branch =~ /^wip_/"
+    command: |
+      wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
+      chmod +x ./comby-1.8.1-x86_64-linux
+      mv comby-1.8.1-x86_64-linux comby
+
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      export PATH=$PATH:$(pwd)
+      ./sg-rfc795 release run internal finalize --workdir=. --config-from-commit
+  - label: "Promote to public: finalize"
+    if: build.branch =~ /^wip-release/
+    command: |
+      wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
+      chmod +x ./comby-1.8.1-x86_64-linux
+      mv comby-1.8.1-x86_64-linux comby
+
+      wget https://storage.googleapis.com/buildkite_public_assets/sg-rfc795.tar.gz
+      tar zxf sg-rfc795.tar.gz
+      chmod +x ./sg-rfc795
+
+      export PATH=$PATH:$(pwd)
+      ./sg-rfc795 release run promote-to-public finalize --workdir=. --config-from-commit

--- a/release.yaml
+++ b/release.yaml
@@ -4,6 +4,8 @@ meta:
   owners:
     - "sourcegraph/release"
   repository: "github.com/sourcegraph/terraform-aws-executors"
+inputs:
+  releaseId: server
 requirements:
   - name: "comby exists"
     cmd: "which comby"
@@ -11,7 +13,6 @@ requirements:
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
-
 internal:
   create:
     steps:
@@ -26,9 +27,9 @@ internal:
           cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
         - name: "files(tf)"
           cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-        - name: "docker:image"
+        - name: "family(name):docker-mirror"
           cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "family:name"
+        - name: "family(name):sourcegraph"
           cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
         - name: "cleanup"
           cmd: |
@@ -42,7 +43,8 @@ internal:
             git push origin ${branch}
         - name: "gh"
           cmd: |
-            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
       major:
         - name: "git:prev_tag"
           cmd: |
@@ -70,13 +72,14 @@ internal:
             git push origin ${branch}
         - name: "gh"
           cmd: |
-            gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
+            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
       - name: "git:finalize"
         cmd: |
           set -e
-          branch="wip-release-{{version}}"
+          branch="wip-internal-release-{{version}}"
           git switch -c "${branch}"
           echo "pushing branch ${branch}"
           git push origin "${branch}"
@@ -124,37 +127,16 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: git:prev_tag
-        cmd: |
-          # get previous tag we need to replace
-          git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-          # convert the tag to the image family format which uses hipens and is only for `major-minor`
-          echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-      - name: "files(README.md)"
-        cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
-      - name: "files(tf)"
-        cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-      - name: "family(docker-mirror)"
-        cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-      - name: "family(sourcegraph-executors)"
-        cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
-      - name: "cleanup"
-        cmd: |
-          rm -vf family_tag
-          rm -vf prev_tag
-      - name: "git:branch"
-        cmd: |
-          branch="promote-release-{{version}}"
-          git switch -c "${branch}"
-          git commit -am 'promote-release: {{version}}' -m '{{config}}'
-          git push origin "${branch}"
-      - name: "gh"
+      - name: git:internal_branch
         cmd: |
           set -e
-          remote_branch="wip-release-{{version}}"
-          # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
-          git fetch origin "${remote_branch}"
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${remote_branch}" --body "Test plan: automated release PR, CI will perform additional checks"
+          branch=wip-internal-release-{{version}}
+          git fetch origin "${branch}
+      - name: "git:branch"
+        cmd: |
+          release_branch="wip-release-{{version}}"
+          git switch -c "${release_branch}"
+          git push origin "${release_branch}"
   finalize:
     steps:
       - name: git:tag

--- a/release.yaml
+++ b/release.yaml
@@ -85,7 +85,7 @@ internal:
       - name: "git:fetch"
         cmd: |
           set -e
-          wip_branch="wip_{{version}}
+          wip_branch="wip_{{version}}"
           git fetch origin "${wip_branch}"
           git checkout "${wip_branch}"
       - name: "git:finalize"

--- a/release.yaml
+++ b/release.yaml
@@ -37,7 +37,7 @@ internal:
             rm -vf prev_tag
         - name: "git:branch"
           cmd: |
-            branch="wb/wip_{{version}}"
+            branch="wip_{{version}}"
             git switch -c "${branch}"
             git commit -am 'release-minor: {{version}}' -m '{{config}}'
             git push origin ${branch}
@@ -66,7 +66,7 @@ internal:
             rm -vf prev_tag
         - name: "git:branch"
           cmd: |
-            branch="wb/wip_{{version}}"
+            branch="wip_{{version}}"
             git switch -c "${branch}"
             git commit -am 'release-minor: {{version}}' -m '{{config}}'
             git push origin ${branch}
@@ -76,10 +76,15 @@ internal:
             --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
-      - name: "git:finalize"
+      - name: "git:fetch"
         cmd: |
           set -e
-          branch="wip-internal-release-{{version}}"
+          wip_branch="wip_{{version}}
+          git fetch origin "${wip_branch}"
+          git checkout "${wip_branch}"
+      - name: "git:finalize"
+        cmd: |
+          finalize_branch="wip-internal-release-{{version}}"
           git switch -c "${branch}"
           echo "pushing branch ${branch}"
           git push origin "${branch}"
@@ -127,19 +132,26 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: git:internal_branch
+      - name: git:fetch_internal
         cmd: |
           set -e
           branch=wip-internal-release-{{version}}
           git fetch origin "${branch}
-      - name: "git:branch"
+      - name: "git:branch_release"
         cmd: |
           release_branch="wip-release-{{version}}"
           git switch -c "${release_branch}"
           git push origin "${release_branch}"
   finalize:
     steps:
-      - name: git:tag
+      - name: git:fetch_release
+        cmd: |
+          set -e
+          wip_branch="wip-release-{{version}}
+          git fetch origin "${wip_branch}"
+          git checkout "${wip_branch}"
+
+      - name: git:tag_release
         cmd: |
           set -e
           branch="wip-release-{{version}}"

--- a/release.yaml
+++ b/release.yaml
@@ -55,26 +55,36 @@ test:
         fi
 
 
-promoteToPublic:
+internal:
   create:
     steps:
-      - name: "update links in READMEs"
-        cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
-      - name: "update version in examples"
-        cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
-      - name: "update executors docker-mirror image name"
-        cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
-      - name: "update executors image name"
-        cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
+      minor:
+        - name: "update links in READMEs"
+          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
+        - name: "update version in examples"
+          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+        - name: "update executors docker-mirror image name"
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
+        - name: "update executors image name"
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
+      major:
+        - name: "update links in READMEs"
+          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
+        - name: "update version in examples"
+          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+        - name: "update executors docker-mirror image name"
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
+        - name: "update executors image name"
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
 
-finalize:
-  steps:
-      - name: "create new branch"
-        cmd: git switch -c "wb/wip-release-{{tag}}"
-      - name: "add changes branch"
-        cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
-      - name: "push branch"
-        cmd: "git push origin wb/wip-release-{{tag}}"
-      - name: "create release PR"
-        cmd: gh pr create --draft --fill
-      # TODO: should we tag here ???
+  finalize:
+    steps:
+        - name: "create new branch"
+          cmd: git switch -c "wb/wip-release-{{tag}}"
+        - name: "add changes branch"
+          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+        - name: "push branch"
+          cmd: "git push origin wb/wip-release-{{tag}}"
+        - name: "create release PR"
+          cmd: gh pr create --draft --fill
+        # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -17,30 +17,58 @@ input:
   - image_family
   - prev_version
 
-internal:
+# No internal steps since any release in this repo is public
+
+test:
+  steps:
+    - name: "correct amount of new version tags in README"
+      cmd: |
+        count=$(grep -c '{{tag}}' README.md)
+        expected=8
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} new version tags of \"{{tag}}\" in README.md, got ${count}"
+          exit 1
+        fi
+    - name: "correct amount of .tf files"
+      cmd: |
+        count=$(comby -match-only '"{{tag}}"' '' -f .tf | wc -l)
+        expected=6
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} .tf files to be updated with \"{{tag}}\" but got ${count}"
+          exit 1
+        fi
+    - name: "sourcegraph-executors-docker-mirror image family has correct version"
+      cmd: |
+        count=$(comby -match-only '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' '' -f .tf | wc -l)
+        expected=1
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
+          exit 1
+        fi
+    - name: "sourcegraph-executors image family has correct version"
+      cmd: |
+        count=$(comby -match-only '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' '' -f .tf | wc -l)
+        expected=1
+        if [[ ${count} -ne ${expected} ]]; then
+          echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
+          exit 1
+        fi
+
+
+promoteToPublic:
   create:
     steps:
-      minor:
-        - name: "update links in READMEs"
-          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
-        - name: "update version in examples"
-          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude proivders.tf
-        - name: "update executors docker-mirror image name"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
-        - name: "update executors image name"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
-      major:
-        - name: "update links in READMEs"
-          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
-        - name: "update version in examples"
-          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude proivders.tf
-        - name: "update executors docker mirror image name"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
-        - name: "update executors image name"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
+      - name: "update links in READMEs"
+        cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
+      - name: "update version in examples"
+        cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+      - name: "update executors docker-mirror image name"
+        cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
+      - name: "update executors image name"
+        cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
 
-  finalize:
-    steps:
+finalize:
+  steps:
       - name: "create new branch"
         cmd: git switch -c "wb/wip-release-{{tag}}"
       - name: "add changes branch"
@@ -49,16 +77,4 @@ internal:
         cmd: "git push origin wb/wip-release-{{tag}}"
       - name: "create release PR"
         cmd: gh pr create --draft --fill
-test:
-  steps:
-    - name: "test test"
-      cmd: "echo 'test test'"
-promoteToPublic:
-  create:
-    steps:
-      - name: "create test"
-        cmd: "echo 'create test'"
-finalize:
-  steps:
-    - name: "finalize test"
-      cmd: "echo 'finalize test'"
+      # TODO: should we tag here ???

--- a/release.yaml
+++ b/release.yaml
@@ -16,21 +16,21 @@ internal:
   create:
     steps:
       minor:
-        - name: generate required files for release process
+        - name: "git:prev_tag"
           cmd: |
             # get previous tag we need to replace
             git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
             # convert the tag to the image family format which uses hipens and is only for `major-minor`
             echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-        - name: "update links in READMEs"
+        - name: "files(README.md)"
           cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
-        - name: "update version in examples"
+        - name: "files(tf)"
           cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-        - name: "update executors docker-mirror image name"
+        - name: "docker:image"
           cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "update executors image name"
+        - name: "family:name"
           cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "remove generated files"
+        - name: "cleanup"
           cmd: |
             rm -vf family_tag
             rm -vf prev_tag
@@ -39,22 +39,26 @@ internal:
             branch="wb/wip_{{version}}"
             git switch -c "${branch}"
             git commit -am 'release-minor: {{version}}' -m '{{config}}'
+            git push origin ${branch}
+        - name: "gh"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
       major:
-        - name: generate required files for release process
+        - name: "git:prev_tag"
           cmd: |
             # get previous tag we need to replace
             git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
             # convert the tag to the image family format which uses hipens and is only for `major-minor`
             echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-        - name: "update links in READMEs"
+        - name: "files(README.md)"
           cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
-        - name: "update version in examples"
+        - name: "files(tf)"
           cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-        - name: "update executors docker-mirror image name"
+        - name: "docker:image"
           cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "update executors image name"
+        - name: "family:name"
           cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "remove generated files"
+        - name: "cleanup"
           cmd: |
             rm -vf family_tag
             rm -vf prev_tag
@@ -62,23 +66,25 @@ internal:
           cmd: |
             branch="wb/wip_{{version}}"
             git switch -c "${branch}"
-            git commit -am 'release-major: {{version}}' -m '{{config}}'
-
+            git commit -am 'release-minor: {{version}}' -m '{{config}}'
+            git push origin ${branch}
+        - name: "gh"
+          cmd: |
+            gh pr create -f -t "PRETEND RELEASE WIP: release_major: build {{version}}" --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:
     steps:
-        - name: "create new branch"
-          cmd: git switch "wb/wip-release-{{tag}}"
-        - name: "add changes branch"
-          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+      - name: "git:finalize"
+        cmd: |
+          set -e
+          branch="wip-release-{{version}}"
+          git switch -c "${branch}"
+          echo "pushing branch ${branch}"
+          git push origin "${branch}"
+          git checkout -
 
-          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
-        - name: "push branch"
-          cmd: "git push origin wb/wip-release-{{tag}}"
-        - name: "create release PR"
-          cmd: gh pr create --draft --fill
 test:
   steps:
-    - name: "correct amount of new version tags in README"
+    - name: "changes:README"
       cmd: |
         count=$(grep -c '{{tag}}' README.md)
         expected=8
@@ -86,7 +92,7 @@ test:
           echo "expected ${expected} new version tags of \"{{tag}}\" in README.md, got ${count}"
           exit 1
         fi
-    - name: "correct amount of .tf files"
+    - name: "changed:tf"
       cmd: |
         count=$(comby -match-only '"{{tag}}"' '' -f .tf | wc -l)
         expected=6
@@ -94,7 +100,7 @@ test:
           echo "expected ${expected} .tf files to be updated with \"{{tag}}\" but got ${count}"
           exit 1
         fi
-    - name: "sourcegraph-executors-docker-mirror image family has correct version"
+    - name: changes:family(docker-mirror)""
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap 'rm -rf family_tag' EXIT
@@ -104,7 +110,7 @@ test:
           echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
           exit 1
         fi
-    - name: "sourcegraph-executors image family has correct version"
+    - name: "changes:family(sourcegraph)"
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap 'rm -rf family_tag' EXIT
@@ -118,31 +124,43 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: generate required files for release process
+      - name: git:prev_tag
         cmd: |
           # get previous tag we need to replace
           git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
           # convert the tag to the image family format which uses hipens and is only for `major-minor`
           echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-      - name: "update links in READMEs"
+      - name: "files(README.md)"
         cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
-      - name: "update version in examples"
+      - name: "files(tf)"
         cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-      - name: "update executors docker-mirror image name"
+      - name: "family(docker-mirror)"
         cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-      - name: "update executors image name"
+      - name: "family(sourcegraph-executors)"
         cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
-      - name: "remove generated files"
+      - name: "cleanup"
         cmd: |
           rm -vf family_tag
           rm -vf prev_tag
       - name: "git:branch"
         cmd: |
-          branch="wb/promote_wip_{{version}}"
+          branch="promote-release-{{version}}"
           git switch -c "${branch}"
           git commit -am 'promote-release: {{version}}' -m '{{config}}'
-      - name: "git:push"
-        cmd: git push origin wb/promote_wip_{{version}}
-      - name: "GitHub:create PR"
+          git push origin "${branch}"
+      - name: "gh"
         cmd: |
-          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}"
+          set -e
+          remote_branch="wip-release-{{version}}"
+          # we need to fetch from origin just in case this branch doesn't exist locally, so that the PR can find the base
+          git fetch origin "${remote_branch}"
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}" --base "${remote_branch}" --body "Test plan: automated release PR, CI will perform additional checks"
+  finalize:
+    steps:
+      - name: git:tag
+        cmd: |
+          set -e
+          branch="wip-release-{{version}}"
+          git checkout "${branch}"
+          git tag wip-{{version}}
+          git push origin ${branch} --tags

--- a/release.yaml
+++ b/release.yaml
@@ -37,12 +37,15 @@ internal:
             rm -vf prev_tag
         - name: "git:branch"
           cmd: |
+            set -e
             branch="wip_{{version}}"
             git switch -c "${branch}"
             git commit -am 'release-minor: {{version}}' -m '{{config}}'
             git push origin ${branch}
         - name: "gh"
           cmd: |
+            # sometimes gh can fail because when it runs the branch is there _yet_, so we do this fetch to make sure it is
+            git fetch origin "wip_{{version}}"
             gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
       major:
@@ -66,12 +69,15 @@ internal:
             rm -vf prev_tag
         - name: "git:branch"
           cmd: |
+            set -e
             branch="wip_{{version}}"
             git switch -c "${branch}"
             git commit -am 'release-minor: {{version}}' -m '{{config}}'
             git push origin ${branch}
         - name: "gh"
           cmd: |
+            # sometimes gh can fail because when it runs the branch is there _yet_, so we do this fetch to make sure it is
+            git fetch origin "wip_{{version}}"
             gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
             --body "Test plan: automated release PR, CI will perform additional checks"
   finalize:

--- a/release.yaml
+++ b/release.yaml
@@ -1,0 +1,64 @@
+---
+meta:
+  productName: "terraform-aws-executors"
+  owners:
+    - "sourcegraph"
+  repository: "github.com/sourcegraph/terraform-aws-executors"
+  artifacts:
+    - "nothing"
+requirements:
+  - name: "comby exists"
+    cmd: "which comby"
+    fixInstructions: "install comby"
+  - name: "GitHub cli exists"
+    cmd: "which gh"
+    fixInstructions: "install GitHub cli"
+input:
+  - image_family
+  - prev_version
+
+internal:
+  create:
+    steps:
+      minor:
+        - name: "update links in READMEs"
+          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
+        - name: "update version in examples"
+          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude proivders.tf
+        - name: "update executors docker-mirror image name"
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
+        - name: "update executors image name"
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
+      major:
+        - name: "update links in READMEs"
+          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
+        - name: "update version in examples"
+          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude proivders.tf
+        - name: "update executors docker mirror image name"
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
+        - name: "update executors image name"
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
+
+  finalize:
+    steps:
+      - name: "create new branch"
+        cmd: git switch -c "wb/wip-release-{{tag}}"
+      - name: "add changes branch"
+        cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+      - name: "push branch"
+        cmd: "git push origin wb/wip-release-{{tag}}"
+      - name: "create release PR"
+        cmd: gh pr create --draft --fill
+test:
+  steps:
+    - name: "test test"
+      cmd: "echo 'test test'"
+promoteToPublic:
+  create:
+    steps:
+      - name: "create test"
+        cmd: "echo 'create test'"
+finalize:
+  steps:
+    - name: "finalize test"
+      cmd: "echo 'finalize test'"

--- a/release.yaml
+++ b/release.yaml
@@ -13,10 +13,6 @@ requirements:
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
-input:
-  - image_family
-  - prev_version
-
 # No internal steps since any release in this repo is public
 
 test:
@@ -39,7 +35,9 @@ test:
         fi
     - name: "sourcegraph-executors-docker-mirror image family has correct version"
       cmd: |
-        count=$(comby -match-only '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' '' -f .tf | wc -l)
+        echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        trap 'rm -rf family_tag' EXIT
+        count=$(comby -match-only "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
@@ -47,7 +45,9 @@ test:
         fi
     - name: "sourcegraph-executors image family has correct version"
       cmd: |
-        count=$(comby -match-only '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' '' -f .tf | wc -l)
+        echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        trap 'rm -rf family_tag' EXIT
+        count=$(comby -match-only "[\"sourcegraph-executors-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
@@ -59,23 +59,43 @@ internal:
   create:
     steps:
       minor:
+        - name: generate required files for release process
+          cmd: |
+            # get previous tag we need to replace
+            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+            # convert the tag to the image family format which uses hipens and is only for `major-minor`
+            echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         - name: "update links in READMEs"
-          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
+          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
         - name: "update version in examples"
-          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
         - name: "update executors docker-mirror image name"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
         - name: "update executors image name"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "remove generated files"
+          cmd: |
+            rm -vf family_tag
+            rm -vf prev_tag
       major:
+        - name: generate required files for release process
+          cmd: |
+            # get previous tag we need to replace
+            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+            # convert the tag to the image family format which uses hipens and is only for `major-minor`
+            echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         - name: "update links in READMEs"
-          cmd: comby -in-place '{{inputs.prev_version.tag}}' '{{tag}}' README.md
+          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
         - name: "update version in examples"
-          cmd: comby '"{{inputs.prev_version.tag}}"' '"{{tag}}"' -i -f .tf -exclude providers.tf
+          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
         - name: "update executors docker-mirror image name"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' '["sourcegraph-executors-docker-mirror-{{inputs.image_family.tag}}-*"]' -i -f .tf
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
         - name: "update executors image name"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' '["sourcegraph-executors-{{inputs.image_family.tag}}-*"]' -i -f .tf
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "remove generated files"
+          cmd: |
+            rm -vf family_tag
+            rm -vf prev_tag
 
   finalize:
     steps:
@@ -83,6 +103,8 @@ internal:
           cmd: git switch -c "wb/wip-release-{{tag}}"
         - name: "add changes branch"
           cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+
+          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
         - name: "push branch"
           cmd: "git push origin wb/wip-release-{{tag}}"
         - name: "create release PR"

--- a/release.yaml
+++ b/release.yaml
@@ -2,10 +2,8 @@
 meta:
   productName: "terraform-aws-executors"
   owners:
-    - "sourcegraph"
+    - "sourcegraph/release"
   repository: "github.com/sourcegraph/terraform-aws-executors"
-  artifacts:
-    - "nothing"
 requirements:
   - name: "comby exists"
     cmd: "which comby"
@@ -13,8 +11,71 @@ requirements:
   - name: "GitHub cli exists"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
-# No internal steps since any release in this repo is public
 
+internal:
+  create:
+    steps:
+      minor:
+        - name: generate required files for release process
+          cmd: |
+            # get previous tag we need to replace
+            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+            # convert the tag to the image family format which uses hipens and is only for `major-minor`
+            echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        - name: "update links in READMEs"
+          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
+        - name: "update version in examples"
+          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+        - name: "update executors docker-mirror image name"
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "update executors image name"
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "remove generated files"
+          cmd: |
+            rm -vf family_tag
+            rm -vf prev_tag
+        - name: "git:branch"
+          cmd: |
+            branch="wb/wip_{{version}}"
+            git switch -c "${branch}"
+            git commit -am 'release-minor: {{version}}' -m '{{config}}'
+      major:
+        - name: generate required files for release process
+          cmd: |
+            # get previous tag we need to replace
+            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+            # convert the tag to the image family format which uses hipens and is only for `major-minor`
+            echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+        - name: "update links in READMEs"
+          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
+        - name: "update version in examples"
+          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+        - name: "update executors docker-mirror image name"
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "update executors image name"
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "remove generated files"
+          cmd: |
+            rm -vf family_tag
+            rm -vf prev_tag
+        - name: "git:branch"
+          cmd: |
+            branch="wb/wip_{{version}}"
+            git switch -c "${branch}"
+            git commit -am 'release-major: {{version}}' -m '{{config}}'
+
+  finalize:
+    steps:
+        - name: "create new branch"
+          cmd: git switch "wb/wip-release-{{tag}}"
+        - name: "add changes branch"
+          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
+
+          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
+        - name: "push branch"
+          cmd: "git push origin wb/wip-release-{{tag}}"
+        - name: "create release PR"
+          cmd: gh pr create --draft --fill
 test:
   steps:
     - name: "correct amount of new version tags in README"
@@ -54,59 +115,34 @@ test:
           exit 1
         fi
 
-
-internal:
+promoteToPublic:
   create:
     steps:
-      minor:
-        - name: generate required files for release process
-          cmd: |
-            # get previous tag we need to replace
-            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-            # convert the tag to the image family format which uses hipens and is only for `major-minor`
-            echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-        - name: "update links in READMEs"
-          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
-        - name: "update version in examples"
-          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-        - name: "update executors docker-mirror image name"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "update executors image name"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "remove generated files"
-          cmd: |
-            rm -vf family_tag
-            rm -vf prev_tag
-      major:
-        - name: generate required files for release process
-          cmd: |
-            # get previous tag we need to replace
-            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-            # convert the tag to the image family format which uses hipens and is only for `major-minor`
-            echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-        - name: "update links in READMEs"
-          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
-        - name: "update version in examples"
-          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-        - name: "update executors docker-mirror image name"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "update executors image name"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "remove generated files"
-          cmd: |
-            rm -vf family_tag
-            rm -vf prev_tag
-
-  finalize:
-    steps:
-        - name: "create new branch"
-          cmd: git switch -c "wb/wip-release-{{tag}}"
-        - name: "add changes branch"
-          cmd: "git commit -am 'WB-WIP: Test Release {{tag}}' -m 'This is a Test release'"
-
-          cmd: "git tag -a {{tag}} -m 'WIP Release {{tag}}'"
-        - name: "push branch"
-          cmd: "git push origin wb/wip-release-{{tag}}"
-        - name: "create release PR"
-          cmd: gh pr create --draft --fill
-        # TODO: should we tag here ???
+      - name: generate required files for release process
+        cmd: |
+          # get previous tag we need to replace
+          git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
+          # convert the tag to the image family format which uses hipens and is only for `major-minor`
+          echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
+      - name: "update links in READMEs"
+        cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
+      - name: "update version in examples"
+        cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+      - name: "update executors docker-mirror image name"
+        cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
+      - name: "update executors image name"
+        cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+      - name: "remove generated files"
+        cmd: |
+          rm -vf family_tag
+          rm -vf prev_tag
+      - name: "git:branch"
+        cmd: |
+          branch="wb/promote_wip_{{version}}"
+          git switch -c "${branch}"
+          git commit -am 'promote-release: {{version}}' -m '{{config}}'
+      - name: "git:push"
+        cmd: git push origin wb/promote_wip_{{version}}
+      - name: "GitHub:create PR"
+        cmd: |
+          gh pr create -f -t "PRETEND PROMOTE RELEASE - release: build {{version}}"


### PR DESCRIPTION
Example release created:
- https://github.com/sourcegraph/terraform-aws-executors/pull/91

Closes https://github.com/sourcegraph/sourcegraph/issues/59065
### Test plan
1. `sg-rfc795 release promote-to-public create --inputs=prev_version=5.2.0,image_family=7-7`
2. `git diff --patch > patch1`
3. `./prepare-release 6.6.666`, also edit script to return tag as '7-7`
4. `git diff --patch > patch2`
5. `diff -y patch1 patch2`, besides the `prepare-release.sh`. Release tooling updated additional readmes as well
