### PR TITLE
release: update regex for `ami_version` variable

### DIFF
--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -32,7 +32,7 @@ variable "ami_version" {
   description = "Specify a Sourcegraph executor ami version to use rather than pulling latest"
 
   validation {
-    condition     = can(regex("^v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
+    condition     = can(regex("^(internal|public-)?v?(\\d+\\.\\d+\\.\\d+(-[0-9A-Za-z-.]+)?(\\+[0-9A-Za-z-.]+)?)?$", var.ami_version))
     error_message = "The Soucegraph ami version must be valid semver."
   }
 }


### PR DESCRIPTION
Part 2 [#61064](https://github.com/sourcegraph/sourcegraph/issues/61064)

With the new release naming for executor AMIs, we'll have internal releases with version like `sourcegraph-executors-internal-5.3.667` and promoted releases with version `sourcegraph-executors-public-5-3-667-2635324`.

Today executor AMI versions are usually in the format `5.3`, so we need to update the regex such that it works for both scenarios for the old and new release methods.

The [`specified_version` variable is appended to `sourcegraph-executors`](https://sourcegraph.com/github.com/sourcegraph/terraform-aws-executors/-/blob/modules/executors/main.tf?L42) when fetching the ami, so this will work provided the `var.ami_version` is usually in the format described in the regex.

### Test plan

CI.
