### PR TITLE
update release manifest for new promotion strategy

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -9,9 +9,11 @@ steps:
     command: .buildkite/shellcheck.sh
     agents: { queue: standard }
   - label: ":terraform:"
+    if: build.branch !~ /^internal\/release-.*/
     command: .buildkite/terraform-validate.sh
     agents: { queue: standard }
   - label: ":lint-roller:"
+    if: build.branch !~ /^internal\/release-.*/
     command: .buildkite/check-latest-tag.sh
     agents: { queue: standard }
   - label: ":lock: security - checkov"
@@ -19,39 +21,47 @@ steps:
     agents: { queue: standard }
     soft_fail: true
 
-  - label: "Release: test"
-    if: "build.branch =~ /^wip_/"
+  - label: "(internal) Release: test"
+    if: build.branch =~ /^internal\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
       wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
       chmod +x ./comby-1.8.1-x86_64-linux
-      mv comby-1.8.1-x86_64-linux comby
+      mv comby-1.8.1-x86_64-linux /usr/local/bin/comby
 
-      export PATH=$PATH:$(pwd)
+      sg release run test --workdir=. --config-from-commit
+
+  - label: "(promote) Release: test"
+    if: build.branch =~ /^promote\/release-.*/
+    plugins:
+      - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
+    command: |
+      wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
+      chmod +x ./comby-1.8.1-x86_64-linux
+      mv comby-1.8.1-x86_64-linux /usr/local/bin/comby
+
       sg release run test --workdir=. --config-from-commit
 
   - wait
 
-  - label: "Release: finalize"
-    if: "build.branch =~ /^wip_/"
+  - label: "(internal) Release: finalize"
+    if: build.branch =~ /^internal\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
       wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
       chmod +x ./comby-1.8.1-x86_64-linux
-      mv comby-1.8.1-x86_64-linux comby
+      mv comby-1.8.1-x86_64-linux /usr/local/bin/comby
 
-      export PATH=$PATH:$(pwd)
       sg release run internal finalize --workdir=. --config-from-commit
-  - label: "Promote to public: finalize"
-    if: build.branch =~ /^wip-release/
+  - label: "(promote) Release: finalize"
+    if: build.branch =~ /^promote\/release-.*/
     plugins:
       - ssh://git@github.com/sourcegraph/sg-buildkite-plugin.git#main: ~
     command: |
       wget https://github.com/comby-tools/comby/releases/download/1.8.1/comby-1.8.1-x86_64-linux
       chmod +x ./comby-1.8.1-x86_64-linux
-      mv comby-1.8.1-x86_64-linux comby
+      mv comby-1.8.1-x86_64-linux /usr/local/bin/comby
 
-      export PATH=$PATH:$(pwd)
       sg release run promote-to-public finalize --workdir=. --config-from-commit

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ terraform 1.1.5
 shfmt 3.2.0
 shellcheck 0.7.1
 python system
+github-cli 2.46.0

--- a/release.yaml
+++ b/release.yaml
@@ -240,7 +240,7 @@ promoteToPublic:
           # Create the final branch holding the tagged commit
           git checkout "${promote_branch}"
           git switch -c "${release_branch}"
-          git tag {{version}}
+          # git tag {{version}}
           git push origin ${release_branch} --tags
 
           # Web URL to the tag

--- a/release.yaml
+++ b/release.yaml
@@ -176,7 +176,7 @@ test:
           family_regex="\"sourcegraph-executors-$(cat family_tag)-*\""
         fi
 
-        count=$(comby -match-only "[\"sourcegraph-executors-internal-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
+        count=$(comby -match-only "${family_regex}" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
@@ -240,7 +240,7 @@ promoteToPublic:
           # Create the final branch holding the tagged commit
           git checkout "${promote_branch}"
           git switch -c "${release_branch}"
-          # git tag {{version}}
+          git tag {{version}}
           git push origin ${release_branch} --tags
 
           # Web URL to the tag

--- a/release.yaml
+++ b/release.yaml
@@ -24,7 +24,7 @@ internal:
             # convert the tag to the image family format which uses hipens and is only for `major-minor`
             echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         - name: "files(README.md)"
-          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
+          cmd: comby "$(cat prev_tag)" '{{tag}}' -i -f .md
         - name: "files(tf)"
           cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
         - name: "family(name):docker-mirror"

--- a/release.yaml
+++ b/release.yaml
@@ -58,7 +58,7 @@ internal:
             gh pr create \
               --fill \
               --draft \
-              --title "(internal) release_patch: build {{version}}" \
+              --title "(internal) release_minor: build {{version}}" \
               --body "Test plan: automated release PR, CI will perform additional checks"
             echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
@@ -103,7 +103,7 @@ internal:
             gh pr create \
               --fill \
               --draft \
-              --title "(internal) release_patch: build {{version}}" \
+              --title "(internal) release_major: build {{version}}" \
               --body "Test plan: automated release PR, CI will perform additional checks"
             echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:

--- a/release.yaml
+++ b/release.yaml
@@ -5,7 +5,7 @@ meta:
     - "sourcegraph/release"
   repository: "github.com/sourcegraph/terraform-aws-executors"
 inputs:
-  releaseId: server
+  - releaseId: server
 requirements:
   - name: "comby"
     cmd: "which comby"
@@ -144,18 +144,38 @@ test:
         fi
     - name: changes:family(docker-mirror)""
       cmd: |
+        set -eu
+
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-        trap 'rm -rf family_tag' EXIT
-        count=$(comby -match-only "[\"sourcegraph-executors-internal-docker-mirror-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
+        trap "rm family_tag" EXIT
+
+        current_branch="${BUILDKITE_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+
+        family_regex="\"sourcegraph-executors-internal-docker-mirror-$(cat family_tag)-*\""
+        if [[ $current_branch =~ ^(promote|release)/.* ]]; then
+          family_regex="\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\""
+        fi
+
+        count=$(comby -match-only "${family_regex}" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
-          echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
+          echo "expected ${expected} .tf files to be updated with \"${family_regex}\" but got ${count}"
           exit 1
         fi
     - name: "changes:family(sourcegraph)"
       cmd: |
+        set -eu
+
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
-        trap 'rm -rf family_tag' EXIT
+        trap "rm family_tag" EXIT
+
+        current_branch="${BUILDKITE_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+
+        family_regex="\"sourcegraph-executors-internal-$(cat family_tag)-*\""
+        if [[ $current_branch =~ ^(promote|release)/.* ]]; then
+          family_regex="\"sourcegraph-executors-$(cat family_tag)-*\""
+        fi
+
         count=$(comby -match-only "[\"sourcegraph-executors-internal-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then

--- a/release.yaml
+++ b/release.yaml
@@ -128,8 +128,8 @@ test:
   steps:
     - name: "changes:README"
       cmd: |
-        count=$(grep -c '{{tag}}' README.md)
-        expected=8
+        count=$(grep -c "5.3.666" --include "README.md" -r . | awk -F ":"  '{sum=sum + $2} END {print sum;}')
+        expected=16
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} new version tags of \"{{tag}}\" in README.md, got ${count}"
           exit 1

--- a/release.yaml
+++ b/release.yaml
@@ -7,10 +7,10 @@ meta:
 inputs:
   releaseId: server
 requirements:
-  - name: "comby exists"
+  - name: "comby"
     cmd: "which comby"
     fixInstructions: "install comby"
-  - name: "GitHub cli exists"
+  - name: "GitHub CLI"
     cmd: "which gh"
     fixInstructions: "install GitHub cli"
 internal:
@@ -28,26 +28,39 @@ internal:
         - name: "files(tf)"
           cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
         - name: "family(name):docker-mirror"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-internal-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
         - name: "family(name):sourcegraph"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-internal-$(cat family_tag)-*\"]" -i -f .tf
         - name: "cleanup"
           cmd: |
+            # remove files we used in previous steps
             rm -vf family_tag
             rm -vf prev_tag
         - name: "git:branch"
           cmd: |
-            set -e
-            branch="wip_{{version}}"
-            git switch -c "${branch}"
-            git commit -am 'release-minor: {{version}}' -m '{{config}}'
-            git push origin ${branch}
-        - name: "gh"
+            set -eu
+            branch="internal/release-{{version}}"
+            echo "Creating branch $branch"
+            git checkout -b $branch
+        - name: "git:commit"
           cmd: |
-            # sometimes gh can fail because when it runs the branch is there _yet_, so we do this fetch to make sure it is
-            git fetch origin "wip_{{version}}"
-            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
-            --body "Test plan: automated release PR, CI will perform additional checks"
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -am "release_minor: {{version}}" -m '{{config}}'
+        - name: "git:push"
+          cmd: |
+            branch="internal/release-{{version}}"
+            git push origin "$branch"
+        - name: "github:pr"
+          cmd: |
+            set -eu
+            gh pr create \
+              --fill \
+              --draft \
+              --title "(internal) release_patch: build {{version}}" \
+              --body "Test plan: automated release PR, CI will perform additional checks"
+            echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
         - name: "git:prev_tag"
           cmd: |
@@ -59,43 +72,57 @@ internal:
           cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
         - name: "files(tf)"
           cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
-        - name: "docker:image"
-          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
-        - name: "family:name"
-          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "family(name):docker-mirror"
+          cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-internal-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "family(name):sourcegraph"
+          cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-internal-$(cat family_tag)-*\"]" -i -f .tf
         - name: "cleanup"
           cmd: |
+            # remove files we used in previous steps
             rm -vf family_tag
             rm -vf prev_tag
         - name: "git:branch"
           cmd: |
-            set -e
-            branch="wip_{{version}}"
-            git switch -c "${branch}"
-            git commit -am 'release-minor: {{version}}' -m '{{config}}'
-            git push origin ${branch}
-        - name: "gh"
+            set -eu
+            branch="internal/release-{{version}}"
+            echo "Creating branch $branch"
+            git checkout -b $branch
+        - name: "git:commit"
           cmd: |
-            # sometimes gh can fail because when it runs the branch is there _yet_, so we do this fetch to make sure it is
-            git fetch origin "wip_{{version}}"
-            gh pr create -f -t "PRETEND RELEASE WIP: release_minor: build {{version}}" \
-            --body "Test plan: automated release PR, CI will perform additional checks"
+            # Careful with the quoting for the config, using double quotes will lead
+            # to the shell dropping out all quotes from the json, leading to failed
+            # parsing.
+            git commit -am "release_major: {{version}}" -m '{{config}}'
+        - name: "git:push"
+          cmd: |
+            branch="internal/release-{{version}}"
+            git push origin "$branch"
+        - name: "github:pr"
+          cmd: |
+            set -eu
+            gh pr create \
+              --fill \
+              --draft \
+              --title "(internal) release_patch: build {{version}}" \
+              --body "Test plan: automated release PR, CI will perform additional checks"
+            echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
-      - name: "git:fetch"
+      - name: "notifications"
         cmd: |
-          set -e
-          wip_branch="wip_{{version}}"
-          git fetch origin "${wip_branch}"
-          git checkout "${wip_branch}"
-      - name: "git:finalize"
-        cmd: |
-          set -e
-          finalize_branch="wip-internal-release-{{version}}"
-          git switch -c "${finalize_branch}"
-          echo "pushing branch ${finalize_branch}"
-          git push origin "${finalize_branch}"
-          git checkout -
+          set -eu
+
+          branch="internal/release-{{version}}"
+
+          # Post a comment on the PR.
+          cat << EOF | gh pr comment "$branch" --body-file -
+          - :green_circle: Internal release is ready for promotion!
+          - :warning: Do not close/merge the pull request or delete the associated branch if you intend to promote it.
+          EOF
+          # Post an annotation.
+          cat << EOF | buildkite-agent annotate --style info
+          Internal release is ready for promotion under the branch [\`$branch\`](https://github.com/sourcegraph/terraform-aws-executors/tree/$branch).
+          EOF
 
 test:
   steps:
@@ -119,7 +146,7 @@ test:
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap 'rm -rf family_tag' EXIT
-        count=$(comby -match-only "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
+        count=$(comby -match-only "[\"sourcegraph-executors-internal-docker-mirror-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
@@ -129,7 +156,7 @@ test:
       cmd: |
         echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         trap 'rm -rf family_tag' EXIT
-        count=$(comby -match-only "[\"sourcegraph-executors-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
+        count=$(comby -match-only "[\"sourcegraph-executors-internal-$(cat family_tag)-*\"]" '' -f .tf | wc -l)
         expected=1
         if [[ ${count} -ne ${expected} ]]; then
           echo "expected ${expected} file to have the correct image family set but got but got ${count} files"
@@ -139,29 +166,80 @@ test:
 promoteToPublic:
   create:
     steps:
-      - name: git:fetch_internal
+      - name: "git"
         cmd: |
-          set -e
-          branch=wip-internal-release-{{version}}
-          git fetch origin "${branch}
-      - name: "git:branch_release"
+          set -eu
+          branch="internal/release-{{version}}"
+          echo "Checking out origin/${branch}"
+          git fetch origin "${branch}"
+          git switch "${branch}"
+      # Since we're promoting to public we need to remove the "internal" from the family
+      - name: "family(name):docker-mirror"
+        cmd: comby '["sourcegraph-executors-internal-docker-mirror-:[family_tag_hole~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-:[family_tag_hole]-*\"]" -i -f .tf
+      - name: "family(name):sourcegraph"
+        cmd: comby '["sourcegraph-executors-internal-:[family_tag_hole~\d+-\d+]-*"]' "[\"sourcegraph-executors-:[family_tag_hole]-*\"]" -i -f .tf
+      - name: "git:branch"
         cmd: |
-          release_branch="wip-release-{{version}}"
-          git switch -c "${release_branch}"
-          git push origin "${release_branch}"
+          set -eu
+          branch="promote/release-{{version}}"
+          git switch -c "${branch}"
+      - name: "git:commit"
+        cmd: |
+          set -eu
+          branch="promote/release-{{version}}"
+          find . -name "*.yaml" | xargs git add
+          find . -name "*.yml" | xargs git add
+
+          # Careful with the quoting for the config, using double quotes will lead
+          # to the shell dropping out all quotes from the json, leading to failed
+          # parsing.
+          git commit -am 'promote-release: {{version}}' -m '{{config}}'
+          git push origin "${branch}"
+      - name: "github:pr"
+        cmd: |
+          set -eu
+          internal_branch="internal/release-{{version}}"
+          gh pr create \
+            --fill \
+            --draft \
+            --base "$internal_branch" \
+            --title "(promote) release: build {{version}}" \
+            --body "Test plan: automated release PR, CI will perform additional checks"
+          echo "🚢 Please check the associated CI build to ensure the process completed".
   finalize:
     steps:
-      - name: git:fetch_release
+      - name: git:tag
         cmd: |
-          set -e
-          wip_branch="wip-release-{{version}}
-          git fetch origin "${wip_branch}"
-          git checkout "${wip_branch}"
+          set -eu
 
-      - name: git:tag_release
-        cmd: |
-          set -e
-          branch="wip-release-{{version}}"
-          git checkout "${branch}"
-          git tag wip-{{version}}
-          git push origin ${branch} --tags
+          # Branches
+          internal_branch="internal/release-{{version}}"
+          promote_branch="promote/release-{{version}}"
+          release_branch="release-{{version}}"
+
+          # Create the final branch holding the tagged commit
+          git checkout "${promote_branch}"
+          git switch -c "${release_branch}"
+          git tag {{version}}
+          git push origin ${release_branch} --tags
+
+          # Web URL to the tag
+          tag_url="https://github.com/sourcegraph/terraform-aws-executors/tree/{{version}}"
+
+          # Annotate PRs
+          cat << EOF | gh pr comment "$internal_branch" --body-file -
+          - :green_circle: Release has been promoted, see tag: $tag_url.
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).
+          - :arrow_right: You can safely close the PR and delete its a associated branch.
+          EOF
+
+          cat << EOF | gh pr comment "$promote_branch" --body-file -
+          - :green_circle: Release has been promoted, see tag: $tag_url.
+          - :no_entry: Do not under any circumstance delete the branch holding the tagged commit (i.e. \`$release_branch\`).
+          - :arrow_right: You can safely close that PR and delete its a associated branch.
+          EOF
+
+          # Annotate build
+          cat << EOF | buildkite-agent annotate --style info
+          Promoted release is **publicly available** through a git tag at [\`{{version}}\`](https://github.com/sourcegraph/terraform-aws-executors/tree/{{version}}).
+          EOF


### PR DESCRIPTION
Part of https://github.com/sourcegraph/sourcegraph/issues/61062

> [!NOTE]
> #### Pipeline changes
> `terraform-validate` and `check-latest-tags` will *never* pass for internal releases since nothing exists publicly and both these steps check public things. Hence on `internal` branches these steps won't execute

> [!NOTE]
> #### Release test steps
> Due to image family changing between releases, the test phase is unable to execute different steps depending on the release phase we're in. This is why we fetch the current branch and check for a different family

### Test plan
- internal release
  -  https://github.com/sourcegraph/terraform-aws-executors/pull/106
- promoted release
  - https://github.com/sourcegraph/terraform-aws-executors/pull/107 