### PR TITLE
release: allow empty commits when promoting a release

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -234,7 +234,7 @@ promoteToPublic:
           # Careful with the quoting for the config, using double quotes will lead
           # to the shell dropping out all quotes from the json, leading to failed
           # parsing.
-          git commit -am 'promote-release: {{version}}' -m '{{config}}'
+          git commit --allow-empty -am 'promote-release: {{version}}' -m '{{config}}'
           git push origin "${branch}"
       - name: "github:pr"
         cmd: |


### PR DESCRIPTION
Because we haven't figured out how internal and public releases would work for the terraform modules, there's no difference between an internal and public release.
Therefor the diff between the internal release branch and promoted release branch shows nothing, which results in `git commit ` step failing.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
Tested during release
