### PR TITLE
release: update files for 5.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ This repository provides a [Terraform module](https://learn.hashicorp.com/tutori
 
 This repository provides four submodules:
 
-1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/executors) provisions compute resources for executors.
-2. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
-3. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
-4. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
+1. The [executors module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/executors) provisions compute resources for executors.
+2. The [docker-mirror module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/docker-mirror) provisions a Docker registry pull-through cache.
+3. The [networking module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/networking) provisions a network to be shared by the executor and Docker registry resources.
+4. The [credentials module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/credentials) provisions credentials required by the Sourcegraph instance to enable observability and auto-scaling of executors.
 
-The [multiple-executors example](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.3.0/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
+The [multiple-executors example](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.6.0/examples/multiple-executors) uses the submodule directly to provision multiple executor resource groups performing different types of work. Follow this example if you are:
 
 1. Provisioning executors for use with multiple features (e.g., both [auto-indexing](https://sourcegraph.com/docs/code_intelligence/explanations/auto_indexing) and [server-side batch changes](https://sourcegraph.com/docs/batch_changes/explanations/server_side)), or
 2. Provisioning resources for multiple Sourcegraph instances (e.g., test, prod)
 
-This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0) combining the executors, network, and docker-mirror resources into an easier to use package.
+This repository also provides a [root module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0) combining the executors, network, and docker-mirror resources into an easier to use package.
 
-The [single-executor example](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.3.0/examples/single-executor) uses the root module to provision a single executor type. Follow this example if you are deploying to a single Sourcegraph instance and using a single executors-backed feature.
+The [single-executor example](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.6.0/examples/single-executor) uses the root module to provision a single executor type. Follow this example if you are deploying to a single Sourcegraph instance and using a single executors-backed feature.
 
 ## Requirements
 
@@ -27,7 +27,7 @@ The [single-executor example](https://github.com/sourcegraph/terraform-aws-execu
   - 4.2.0 and above: `>= 1.1.0, < 2.0.0`
 - [hashicorp/aws](https://registry.terraform.io/providers/hashicorp/aws) 
   - 4.1.0 and below: `~> 3.0.0`
-  - 4.2.0 and above: `>= 3.0, < 5.3.0`
+  - 4.2.0 and above: `>= 3.0, < 5.6.0`
 
 ## Setup
 

--- a/examples/multiple-executors/README.md
+++ b/examples/multiple-executors/README.md
@@ -1,6 +1,6 @@
 # Multiple executor example
 
-This example uses [networking](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/networking), [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/docker-mirror), and [executors](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/executors) submodules that provision a network, a Docker registry mirror, and sets of resources running one or more types of executors.
+This example uses [networking](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/networking), [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/docker-mirror), and [executors](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/executors) submodules that provision a network, a Docker registry mirror, and sets of resources running one or more types of executors.
 
 The following variables must be supplied:
 
@@ -10,4 +10,4 @@ The following variables must be supplied:
 
 If your deployment environment already has a Docker registry that can be used, only the `executor` submodule must be used (and references to the `networking` and `docker-mirror` modules can be dropped). The Docker registry mirror address can be supplied along with its containing VPC and subnet as pre-existing identifier literals.
 
-All of these module's variables are defined in [modules/networking/variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.3.0/modules/networking/variables.tf), [modules/docker-mirror/variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.3.0/modules/docker-mirror/variables.tf), and [modules/executors/variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.3.0/modules/executors/variables.tf).
+All of these module's variables are defined in [modules/networking/variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.6.0/modules/networking/variables.tf), [modules/docker-mirror/variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.6.0/modules/docker-mirror/variables.tf), and [modules/executors/variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.6.0/modules/executors/variables.tf).

--- a/examples/multiple-executors/main.tf
+++ b/examples/multiple-executors/main.tf
@@ -6,7 +6,7 @@ locals {
 
 module "networking" {
   source  = "sourcegraph/executors/aws//modules/networking"
-  version = "5.3.0" # LATEST
+  version = "5.6.0" # LATEST
 
   availability_zone        = local.availability_zone
   randomize_resource_names = true
@@ -14,7 +14,7 @@ module "networking" {
 
 module "docker-mirror" {
   source  = "sourcegraph/executors/aws//modules/docker-mirror"
-  version = "5.3.0" # LATEST
+  version = "5.6.0" # LATEST
 
   vpc_id                   = module.networking.vpc_id
   subnet_id                = module.networking.subnet_id
@@ -25,7 +25,7 @@ module "docker-mirror" {
 
 module "executors-codeintel" {
   source  = "sourcegraph/executors/aws//modules/executors"
-  version = "5.3.0" # LATEST
+  version = "5.6.0" # LATEST
 
   vpc_id                              = module.networking.vpc_id
   subnet_id                           = module.networking.subnet_id
@@ -43,7 +43,7 @@ module "executors-codeintel" {
 
 module "executors-batches" {
   source  = "sourcegraph/executors/aws//modules/executors"
-  version = "5.3.0" # LATEST
+  version = "5.6.0" # LATEST
 
   vpc_id                              = module.networking.vpc_id
   subnet_id                           = module.networking.subnet_id

--- a/examples/private-single-executor/main.tf
+++ b/examples/private-single-executor/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "executors" {
   source  = "sourcegraph/executors/aws"
-  version = "5.3.0" # LATEST
+  version = "5.6.0" # LATEST
 
   availability_zone                            = local.availability_zone
   executor_instance_tag                        = "codeintel-prod"

--- a/examples/single-executor/README.md
+++ b/examples/single-executor/README.md
@@ -1,6 +1,6 @@
 # Single executor example
 
-This example uses the [root module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0) that provisions a network, a Docker registry mirror, and a set of resources to run _one_ type of executor. To provision more than one type of executor (multiple queues or multiple environments), see the following `multiple-executors` example.
+This example uses the [root module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0) that provisions a network, a Docker registry mirror, and a set of resources to run _one_ type of executor. To provision more than one type of executor (multiple queues or multiple environments), see the following `multiple-executors` example.
 
 The following variables must be supplied:
 
@@ -12,4 +12,4 @@ The following variables must be supplied:
 - `executor_metrics_environment_label`: The name of the target environment (e.g., `staging`, `prod`). This value must be the same as the `EXECUTOR_METRIC_ENVIRONMENT_LABEL` environment variable as described in [Configuring auto scaling](https://docs.sourcegraph.com/admin/deploy_executors#aws).
 - `executor_instance_tag`: Compute instances are tagged by this value by the key `executor_tag`. We recommend this value take the form `{executor_queue_name}-{executor_metrics_environment_label}`. This value must be the same as `INSTANCE_TAG` as described in [Configuring observability](https://docs.sourcegraph.com/admin/deploy_executors#aws-1).
 
-All of this module's variables are defined in [variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.3.0/variables.tf).
+All of this module's variables are defined in [variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v5.6.0/variables.tf).

--- a/examples/single-executor/main.tf
+++ b/examples/single-executor/main.tf
@@ -5,7 +5,7 @@ locals {
 
 module "executors" {
   source  = "sourcegraph/executors/aws"
-  version = "5.3.0" # LATEST
+  version = "5.6.0" # LATEST
 
   availability_zone                            = local.availability_zone
   executor_instance_tag                        = "codeintel-prod"

--- a/modules/docker-mirror/README.md
+++ b/modules/docker-mirror/README.md
@@ -2,4 +2,4 @@
 
 This module provides a hosted Docker registry pull-through cache to be used by [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors). It is strongly recommended to deploy a Docker mirror as a cache to reduce rate limiting by the public [Docker Hub registry](https://hub.docker.com/). We have also seen deploying a Docker mirror in the same physical zone as the executors significantly decreased latencies during image pulls.
 
-When using the sibling [executors module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/executors), the `vpc_id` and `subnet_id` values must match and the executor module `docker_registry_mirror` value should match `"http://${static_ip}:5000"`.
+When using the sibling [executors module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/executors), the `vpc_id` and `subnet_id` values must match and the executor module `docker_registry_mirror` value should match `"http://${static_ip}:5000"`.

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -48,7 +48,7 @@ data "aws_ami" "latest_ami" {
 
   filter {
     name   = "name"
-    values = ["sourcegraph-executors-docker-mirror-5-3-*"]
+    values = ["sourcegraph-executors-docker-mirror-5-6-*"]
   }
 
   filter {

--- a/modules/executors/README.md
+++ b/modules/executors/README.md
@@ -1,6 +1,6 @@
 # Executors module
 
-This module provides the resources to provision [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) compute resources on AWS. For a high-level overview of the resources deployed by this module, see the [root module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0). This module includes the following resources:
+This module provides the resources to provision [Sourcegraph executor](https://docs.sourcegraph.com/admin/executors) compute resources on AWS. For a high-level overview of the resources deployed by this module, see the [root module](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0). This module includes the following resources:
 
 - AWS launch template
 - AWS autoscaler and autoscaling policy
@@ -10,4 +10,4 @@ This module provides the resources to provision [Sourcegraph executor](https://d
 
 This module does **not** automatically create networking or Docker mirror resources. The `vpc_id`, `subnet_id`, and `docker_registry_mirror` variables must be supplied explicitly with resources that have been previously created.
 
-This module is often used with the sibling modules that create [networking](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/networking) and [Docker mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/docker-mirror) resources which can be shared by multiple instances of the executor module (listening to different queues or being deployed in a different environment).
+This module is often used with the sibling modules that create [networking](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/networking) and [Docker mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/docker-mirror) resources which can be shared by multiple instances of the executor module (listening to different queues or being deployed in a different environment).

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -153,7 +153,7 @@ data "aws_ami" "latest_ami" {
 
   filter {
     name   = "name"
-    values = ["sourcegraph-executors-5-3-*"]
+    values = ["sourcegraph-executors-5-6-*"]
   }
 
   filter {

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -1,6 +1,6 @@
 # Networking module
 
-This module provides the networking glue between the sibling [executors](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/executors) and [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.3.0/submodules/docker-mirror) modules.
+This module provides the networking glue between the sibling [executors](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/executors) and [docker-mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/5.6.0/submodules/docker-mirror) modules.
 
 This module is very simple, creating only a network and a subnet by default.
 


### PR DESCRIPTION
Reading the `RELEASE.md` file and the CI check that is failing, it appears this is _expected_ behavior when updating as the current branch doesn't have access to the latest tag... 🤔 

### Test plan

Release changes via documented release procedure. 

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
