### PR TITLE
update terraform providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ The [single-executor example](https://github.com/sourcegraph/terraform-aws-execu
 - [Terraform](https://www.terraform.io/) 
   - 4.1.0 and below: `~> 1.1.0`
   - 4.2.0 and above: `>= 1.1.0, < 2.0.0`
-- [hashicorp/aws](https://registry.terraform.io/providers/hashicorp/aws) 
-  - 4.1.0 and below: `~> 3.0.0`
-  - 4.2.0 and above: `>= 3.0, < 7.3.0`
+- [hashicorp/aws](https://registry.terraform.io/providers/hashicorp/aws): `>= 5.0, < 7.0`
 
 ## Setup
 

--- a/examples/multiple-executors/.terraform.lock.hcl
+++ b/examples/multiple-executors/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = ">= 5.0.0, < 7.0.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.9.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/examples/multiple-executors/main.tf
+++ b/examples/multiple-executors/main.tf
@@ -5,16 +5,14 @@ locals {
 }
 
 module "networking" {
-  source  = "sourcegraph/executors/aws//modules/networking"
-  version = "7.3.0" # LATEST
+  source = "../../modules/networking"
 
   availability_zone        = local.availability_zone
   randomize_resource_names = true
 }
 
 module "docker-mirror" {
-  source  = "sourcegraph/executors/aws//modules/docker-mirror"
-  version = "7.3.0" # LATEST
+  source = "../../modules/docker-mirror"
 
   vpc_id                   = module.networking.vpc_id
   subnet_id                = module.networking.subnet_id
@@ -24,8 +22,7 @@ module "docker-mirror" {
 }
 
 module "executors-codeintel" {
-  source  = "sourcegraph/executors/aws//modules/executors"
-  version = "7.3.0" # LATEST
+  source = "../../modules/executors"
 
   vpc_id                              = module.networking.vpc_id
   subnet_id                           = module.networking.subnet_id
@@ -42,8 +39,7 @@ module "executors-codeintel" {
 }
 
 module "executors-batches" {
-  source  = "sourcegraph/executors/aws//modules/executors"
-  version = "7.3.0" # LATEST
+  source = "../../modules/executors"
 
   vpc_id                              = module.networking.vpc_id
   subnet_id                           = module.networking.subnet_id

--- a/examples/multiple-executors/providers.tf
+++ b/examples/multiple-executors/providers.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
 provider "aws" {
   region = local.region
 

--- a/examples/private-single-executor/.terraform.lock.hcl
+++ b/examples/private-single-executor/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = ">= 5.0.0, < 7.0.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.9.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/examples/private-single-executor/main.tf
+++ b/examples/private-single-executor/main.tf
@@ -4,8 +4,7 @@ locals {
 }
 
 module "executors" {
-  source  = "sourcegraph/executors/aws"
-  version = "7.3.0" # LATEST
+  source = "../../"
 
   availability_zone                            = local.availability_zone
   executor_instance_tag                        = "codeintel-prod"

--- a/examples/private-single-executor/providers.tf
+++ b/examples/private-single-executor/providers.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
 provider "aws" {
   region = local.region
 

--- a/examples/single-executor/.terraform.lock.hcl
+++ b/examples/single-executor/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.53.0"
+  constraints = ">= 5.0.0, < 7.0.0"
+  hashes = [
+    "h1:UFEhEEFJcR/pAOZcwdR11gN9W3X8VwvSl1IS0vbj2G0=",
+    "zh:0757ce9d5a30e8225521857924f5d6c49e5885fd9e309e56193c9c9920b3f8f0",
+    "zh:10ddb3a20e0779788e8002bc67d184eb166dec70f9d07220bfc55e15c3e5e206",
+    "zh:1e943f59a8c3f3b04f09fd5d967fef2518e0ce3ec4959e31f5d7f820660e8524",
+    "zh:21d55ad3b28f48c6dd34faceeb1fd1fe2ec3b1aaecfc5eb0e0841884f6520d69",
+    "zh:2e551bc0ff29ea608a99f63d899afbdf2f23c14035f27dc0c0bdca60209d9575",
+    "zh:581db963564364200426f2a4be866470a975cde6a4bd6fd09362ec2bab119cbb",
+    "zh:71a7abc88e16ccbe4410fc4966bd35fae9e0161c1385a9b3c19800e3db626b01",
+    "zh:8767767776c45590d4cc74b4c37f6377e05ce75039a9c2e834de0bbcc29f7a1a",
+    "zh:99c8e37beb9b1017f67c41e402031559b745fa797848f1a4ef8b40421dee3f05",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ba1477eda2f3ee51846492449338146f80806088d2952c08c2f8af874550a75d",
+    "zh:c389f68ba4d39fa2bf8a54d4af7f7b2132da2a964c260892c1dd1a89b67e61f8",
+    "zh:d7381490a637a1fa45769d0ee6b3e0578cce488d078077ec63d9090113784f2a",
+    "zh:df3b82fb1a675fc6548fac2fff10a8741efa5bcb5a53d01d8f0659179a2f717f",
+    "zh:e5d78b2ac3dc5477cf21d7cd4c8b9e3d944ff091e90b62c1b2ea9cc7c7eef57c",
+    "zh:fd224078287c6d82de2ec30ea03d3d550c2c554e372b234f7a6ac2b07c23dba0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.9.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/examples/single-executor/main.tf
+++ b/examples/single-executor/main.tf
@@ -4,8 +4,7 @@ locals {
 }
 
 module "executors" {
-  source  = "sourcegraph/executors/aws"
-  version = "7.3.0" # LATEST
+  source = "../../"
 
   availability_zone                            = local.availability_zone
   executor_instance_tag                        = "codeintel-prod"

--- a/examples/single-executor/providers.tf
+++ b/examples/single-executor/providers.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
 provider "aws" {
   region = local.region
 

--- a/modules/credentials/providers.tf
+++ b/modules/credentials/providers.tf
@@ -1,6 +1,9 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, < 5.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
   }
 }

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -107,6 +107,12 @@ resource "aws_instance" "default" {
 
   monitoring = true
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
   # We attach the static network device to the mirror instance.
   network_interface {
     device_index         = 0

--- a/modules/docker-mirror/main.tf
+++ b/modules/docker-mirror/main.tf
@@ -142,7 +142,7 @@ resource "random_id" "eip" {
 resource "aws_eip" "static" {
   count = var.assign_public_ip ? 1 : 0
 
-  vpc                       = true
+  domain                    = "vpc"
   associate_with_private_ip = var.static_ip
   network_interface         = aws_network_interface.static.id
 

--- a/modules/docker-mirror/providers.tf
+++ b/modules/docker-mirror/providers.tf
@@ -1,6 +1,9 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, < 5.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
   }
 }

--- a/modules/executors/main.tf
+++ b/modules/executors/main.tf
@@ -224,6 +224,12 @@ resource "aws_launch_template" "executor" {
     security_groups = [var.metrics_access_security_group_id != "" ? var.metrics_access_security_group_id : aws_security_group.metrics_access[0].id]
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
   monitoring {
     enabled = true
   }

--- a/modules/executors/providers.tf
+++ b/modules/executors/providers.tf
@@ -1,6 +1,9 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, < 5.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
   }
 }

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -163,7 +163,7 @@ resource "aws_eip" "nat" {
   # Only create this resource when NAT is enabled.
   count = var.nat ? 1 : 0
 
-  vpc        = true
+  domain     = "vpc"
   depends_on = [aws_internet_gateway.default]
 
   tags = {

--- a/modules/networking/providers.tf
+++ b/modules/networking/providers.tf
@@ -1,6 +1,9 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, < 5.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,9 @@
 terraform {
   required_version = ">= 1.1.0, < 2.0.0"
   required_providers {
-    aws = ">= 3.0, < 5.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
   }
 }


### PR DESCRIPTION
Closes PLAT-741

This PR updates the aws providers in the `terraform-aws-executors` repo.

### Test plan
These changes were tested by deploying to aws https://us-west-2.console.aws.amazon.com/ec2/home?region=us-west-2#Instances:
<img width="2560" height="439" alt="Screenshot 2026-07-07 at 8 02 43 PM" src="https://github.com/user-attachments/assets/1aa551b1-3fc7-430f-9829-84749a990551" />

Using the following charts
```
➜  test-clouddev git:(wg/plat/executors-terraform-cleanup) ✗ cat main.tf
locals {
  region            = "us-west-2"
  availability_zone = "us-west-2a"
}

module "executors" {
  source = "../"

  availability_zone                            = local.availability_zone
  executor_instance_tag                        = "executor-aws-clouddev-test"
  executor_sourcegraph_external_url            = "https://clouddev-qa.sgdev.dev"
  executor_sourcegraph_executor_proxy_password = "REDACTED"
  executor_queue_names                         = ["codeintel"]
  executor_metrics_environment_label           = "clouddev-test"
  executor_use_firecracker                     = true
  executor_min_replicas                        = 1
  executor_max_replicas                        = 1
  randomize_resource_names                     = true
}
➜  test-clouddev git:(wg/plat/executors-terraform-cleanup) ✗ cat providers.tf
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = ">= 5.0, < 7.0"
    }
  }
}

provider "aws" {
  region  = local.region
  profile = "michael-dev"
}
```

This shows up in the UI https://clouddev-qa.sgdev.dev/admin/executors
<img width="1403" height="535" alt="Screenshot 2026-07-07 at 7 44 37 PM" src="https://github.com/user-attachments/assets/1815ba9b-9503-4fbe-b424-30bd8b7bd800" />

### Upgrade test

Validated the upgrade path from the published registry module to this branch:

1. **Fresh deploy with current published version:** `source = "sourcegraph/executors/aws"` `version = "7.3.0"` + AWS provider `~> 4.67` (resolved to `4.67.0`). `terraform apply` created 43 resources successfully.

2. **Upgrade to this branch:** Switched to `source = "../"` (this branch) + AWS provider `>= 5.0, < 7.0` (resolved to `6.53.0`). Ran `terraform init -upgrade` then `terraform plan`:

```
Plan: 0 to add, 1 to change, 0 to destroy.
```

The only change is the new IMDSv2 `metadata_options` block on the launch template (in-place update):

```
  # module.executors.module.aws-executor.aws_launch_template.executor will be updated in-place
  ~ resource "aws_launch_template" "executor" {
      + metadata_options {
          + http_endpoint               = "enabled"
          + http_put_response_hop_limit = 1
          + http_tokens                 = "required"
        }
    }
```

`terraform apply` completed in 6 seconds. Zero resources destroyed or recreated. The `domain = "vpc"` EIP fix is backward-compatible — Terraform treats it as equivalent for existing resources. Existing ASG instances continue running; new instances will get IMDSv2.

One deprecation warning (cosmetic, not introduced by this PR):
```
│ Warning: Argument is deprecated
│   with module.executors.module.aws-docker-mirror.aws_instance.default,
│   network_interface is deprecated. Use primary_network_interface instead.
```
