### PR TITLE
release: update stale module references reliably

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -17,25 +17,51 @@ internal:
   create:
     steps:
       minor:
-        - name: "git:prev_tag"
+        - name: "release:setup"
           cmd: |
-            # get previous tag we need to replace
-            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-            # convert the tag to the image family format which uses hipens and is only for `major-minor`
+            # Convert the tag to the image family format, which uses hyphens and only major-minor.
             echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         - name: "files(README.md)"
-          cmd: comby "$(cat prev_tag)" '{{tag}}' -i -f .md
+          cmd: |
+            comby 'registry.terraform.io/modules/sourcegraph/executors/aws/:[version~\d+\.\d+\.\d+]' 'registry.terraform.io/modules/sourcegraph/executors/aws/{{tag}}' -i -f .md
+            comby 'github.com/sourcegraph/terraform-aws-executors/blob/v:[version~\d+\.\d+\.\d+]' 'github.com/sourcegraph/terraform-aws-executors/blob/v{{tag}}' -i -f .md
         - name: "files(tf)"
-          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+          cmd: |
+            comby 'version = ":[version~\d+\.\d+\.\d+]" # LATEST' 'version = "{{tag}}" # LATEST' -i -f .tf
         - name: "family(name):docker-mirror"
           cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
         - name: "family(name):sourcegraph"
           cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "release:verify"
+          cmd: |
+            set -eu
+            family_tag=$(cat family_tag)
+
+            grep -Fq "sourcegraph-executors-docker-mirror-${family_tag}-*" modules/docker-mirror/main.tf
+            grep -Fq "sourcegraph-executors-${family_tag}-*" modules/executors/main.tf
+
+            if grep -REh --include='*.md' 'registry\.terraform\.io/modules/sourcegraph/executors/aws/[0-9]+\.[0-9]+\.[0-9]+|github\.com/sourcegraph/terraform-aws-executors/blob/v[0-9]+\.[0-9]+\.[0-9]+' . | grep -Fv '{{tag}}'; then
+              echo "Found a stale Terraform module reference after release updates"
+              exit 1
+            fi
+
+            if grep -REh --include='*.tf' 'version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*# LATEST' . | grep -Fv '"{{tag}}"'; then
+              echo "Found a stale Terraform module version after release updates"
+              exit 1
+            fi
+
+            git diff --quiet -- modules/docker-mirror/main.tf && {
+              echo "Docker mirror image family was not updated"
+              exit 1
+            }
+            git diff --quiet -- modules/executors/main.tf && {
+              echo "Executor image family was not updated"
+              exit 1
+            }
         - name: "cleanup"
           cmd: |
             # remove files we used in previous steps
             rm -vf family_tag
-            rm -vf prev_tag
         - name: "git:branch"
           cmd: |
             set -eu
@@ -62,25 +88,51 @@ internal:
               --body "Test plan: automated release PR, CI will perform additional checks"
             echo "🚢 Please check the associated CI build to ensure the process completed".
       major:
-        - name: "git:prev_tag"
+        - name: "release:setup"
           cmd: |
-            # get previous tag we need to replace
-            git describe --tags "$(git rev-list --tags --max-count=1)" | sed 's/v//' > prev_tag
-            # convert the tag to the image family format which uses hipens and is only for `major-minor`
+            # Convert the tag to the image family format, which uses hyphens and only major-minor.
             echo "{{tag}}" | grep -o -E "[[:digit:]]+\.[[:digit:]]+" | sed 's/\./-/' > family_tag
         - name: "files(README.md)"
-          cmd: comby -in-place "$(cat prev_tag)" '{{tag}}' README.md
+          cmd: |
+            comby 'registry.terraform.io/modules/sourcegraph/executors/aws/:[version~\d+\.\d+\.\d+]' 'registry.terraform.io/modules/sourcegraph/executors/aws/{{tag}}' -i -f .md
+            comby 'github.com/sourcegraph/terraform-aws-executors/blob/v:[version~\d+\.\d+\.\d+]' 'github.com/sourcegraph/terraform-aws-executors/blob/v{{tag}}' -i -f .md
         - name: "files(tf)"
-          cmd: comby "\"$(cat prev_tag)\"" '"{{tag}}"' -i -f .tf -exclude providers.tf
+          cmd: |
+            comby 'version = ":[version~\d+\.\d+\.\d+]" # LATEST' 'version = "{{tag}}" # LATEST' -i -f .tf
         - name: "family(name):docker-mirror"
           cmd: comby '["sourcegraph-executors-docker-mirror-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-docker-mirror-$(cat family_tag)-*\"]" -i -f .tf
         - name: "family(name):sourcegraph"
           cmd: comby '["sourcegraph-executors-:[~\d+-\d+]-*"]' "[\"sourcegraph-executors-$(cat family_tag)-*\"]" -i -f .tf
+        - name: "release:verify"
+          cmd: |
+            set -eu
+            family_tag=$(cat family_tag)
+
+            grep -Fq "sourcegraph-executors-docker-mirror-${family_tag}-*" modules/docker-mirror/main.tf
+            grep -Fq "sourcegraph-executors-${family_tag}-*" modules/executors/main.tf
+
+            if grep -REh --include='*.md' 'registry\.terraform\.io/modules/sourcegraph/executors/aws/[0-9]+\.[0-9]+\.[0-9]+|github\.com/sourcegraph/terraform-aws-executors/blob/v[0-9]+\.[0-9]+\.[0-9]+' . | grep -Fv '{{tag}}'; then
+              echo "Found a stale Terraform module reference after release updates"
+              exit 1
+            fi
+
+            if grep -REh --include='*.tf' 'version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*# LATEST' . | grep -Fv '"{{tag}}"'; then
+              echo "Found a stale Terraform module version after release updates"
+              exit 1
+            fi
+
+            git diff --quiet -- modules/docker-mirror/main.tf && {
+              echo "Docker mirror image family was not updated"
+              exit 1
+            }
+            git diff --quiet -- modules/executors/main.tf && {
+              echo "Executor image family was not updated"
+              exit 1
+            }
         - name: "cleanup"
           cmd: |
             # remove files we used in previous steps
             rm -vf family_tag
-            rm -vf prev_tag
         - name: "git:branch"
           cmd: |
             set -eu

--- a/release.yaml
+++ b/release.yaml
@@ -41,13 +41,11 @@ internal:
             grep -Fq "sourcegraph-executors-${family_tag}-*" modules/executors/main.tf
 
             if grep -REh --include='*.md' 'registry\.terraform\.io/modules/sourcegraph/executors/aws/[0-9]+\.[0-9]+\.[0-9]+|github\.com/sourcegraph/terraform-aws-executors/blob/v[0-9]+\.[0-9]+\.[0-9]+' . | grep -Fv '{{tag}}'; then
-              echo "Found a stale Terraform module reference after release updates"
-              exit 1
+              echo "WARNING: Found a stale Terraform module reference after release updates"
             fi
 
             if grep -REh --include='*.tf' 'version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*# LATEST' . | grep -Fv '"{{tag}}"'; then
-              echo "Found a stale Terraform module version after release updates"
-              exit 1
+              echo "WARNING: Found a stale Terraform module version after release updates"
             fi
 
             git diff --quiet -- modules/docker-mirror/main.tf && {
@@ -112,13 +110,11 @@ internal:
             grep -Fq "sourcegraph-executors-${family_tag}-*" modules/executors/main.tf
 
             if grep -REh --include='*.md' 'registry\.terraform\.io/modules/sourcegraph/executors/aws/[0-9]+\.[0-9]+\.[0-9]+|github\.com/sourcegraph/terraform-aws-executors/blob/v[0-9]+\.[0-9]+\.[0-9]+' . | grep -Fv '{{tag}}'; then
-              echo "Found a stale Terraform module reference after release updates"
-              exit 1
+              echo "WARNING: Found a stale Terraform module reference after release updates"
             fi
 
             if grep -REh --include='*.tf' 'version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"[[:space:]]*# LATEST' . | grep -Fv '"{{tag}}"'; then
-              echo "Found a stale Terraform module version after release updates"
-              exit 1
+              echo "WARNING: Found a stale Terraform module version after release updates"
             fi
 
             git diff --quiet -- modules/docker-mirror/main.tf && {


### PR DESCRIPTION
closes EPD2-344

## Problem

The release workflow derives `prev_tag` from the latest Git tag and replaces only that exact version in Markdown and Terraform files. Because release PRs are not necessarily merged into `main`, those files can contain an older version. The replacement then silently misses them, as happened during the v7.5.0 release.

## Fix

Replace Sourcegraph Terraform Registry links, repository links, and `# LATEST` module pins based on their contextual version patterns instead of the latest tag. Provider constraints remain untouched. The workflow also verifies that both required AWS executor AMI-family selectors changed. Remaining stale documentation or example references emit warnings without blocking publication; missing AMI-family updates remain blocking.

## Testing

- Parsed `release.yaml` locally with `yq`.
- Validated every minor and major release command with `sh -n`.
- Ran the Comby transformations against a temporary repository copy using version 7.6.0.
- Confirmed expected Markdown references and AMI-family selectors changed.
- Confirmed unrelated provider versions were unchanged.
- Ran `git diff --check`.

No complete `sg release create` was run because it would push a release branch and open another PR.