### PR TITLE
Document executor instance sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ The [single-executor example](https://github.com/sourcegraph/terraform-aws-execu
 Please follow our [setup guide](https://sourcegraph.com/docs/admin/executors/deploy_executors_terraform) on how to deploy
 executors using Terraform.
 
+### Sizing executor instances
+
+The root module uses `executor_machine_type` to select the EC2 instance type and defaults to `c5n.metal` (72 vCPUs and 192 GiB of memory). `c5n.metal` is not required: you can use any instance that meets the isolation requirements below. Choose its size based on per-job resources, concurrency, and measured workload, as described in Sourcegraph's [executor capacity guidance](https://sourcegraph.com/docs/self-hosted/executors/resource-sizing).
+
+Sourcegraph's [binary deployment requirements](https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#dependencies) specify that, when Firecracker isolation is enabled, the instance must be amd64 and expose KVM at `/dev/kvm`. You can use a bare-metal instance or a non-metal instance with AWS nested virtualization enabled. As of August 2026, [AWS supports nested virtualization](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html#nested-virtualization-considerations) on the following Intel-based families: `C8i`, `M8i`, `R8i`, `C8id`, `M8id`, `R8id`, `C8i-flex`, `M8i-flex`, `R8i-flex`, `X8i`, `C7i`, `M7i`, `R7i`, `C7i-flex`, `M7i-flex`, and `I7i`. Nitro-based instances outside this list are not necessarily supported.
+
+[AWS requires nested virtualization to be enabled](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html#nested-virtualization-launch-new-instance) as an EC2 CPU option when launching a supported non-metal instance; selecting the instance type alone does not enable it. If Firecracker isolation is disabled, KVM is not required.
+
+Each executor instance can run up to `executor_maximum_num_jobs` jobs concurrently (18 by default), and each job can use the resources configured by `executor_job_num_cpus` (4 by default) and `executor_job_memory` (`12GB` by default).
+
+Following Sourcegraph's [capacity calculation](https://sourcegraph.com/docs/self-hosted/executors/resource-sizing#calculate-capacity-for-concurrent-jobs), estimate the maximum concurrent demand as:
+
+- vCPUs: `executor_maximum_num_jobs * executor_job_num_cpus`
+- memory: `executor_maximum_num_jobs * executor_job_memory`
+- Firecracker disk: `executor_maximum_num_jobs * executor_firecracker_disk_space`
+
+These products are worst-case capacity-planning values, not reservations. The defaults allow overcommit on the assumption that jobs do not all reach every limit simultaneously. If that assumption does not fit your workload, select a larger instance or reduce `executor_maximum_num_jobs` and the per-job limits. Leave capacity for the operating system, the executor process, VM images, job workspaces, and other overhead. The root module's `executor_boot_disk_size` defaults to 100 GB.
+
+When `executor_use_firecracker` is enabled (the default), `executor_job_num_cpus` must be either `1` or an even number. `executor_firecracker_disk_space` must also be set to a valid data size such as `20GB` (the default). Before deploying, verify that the selected instance exposes `/dev/kvm`.
+
+If you use the `executors` submodule directly, use the corresponding unprefixed variables: `machine_type`, `maximum_num_jobs`, `job_num_cpus`, `job_memory`, `firecracker_disk_space`, and `boot_disk_size`.
+
 ### Custom Security Group
 
 By default, the Terraform module will create two security groups. One for the Docker Mirror and the other for 

--- a/examples/single-executor/README.md
+++ b/examples/single-executor/README.md
@@ -13,3 +13,5 @@ The following variables must be supplied:
 - `executor_instance_tag`: Compute instances are tagged by this value by the key `executor_tag`. We recommend this value take the form `{executor_queue_name}-{executor_metrics_environment_label}`. This value must be the same as `INSTANCE_TAG` as described in [Configuring observability](https://docs.sourcegraph.com/admin/deploy_executors#aws-1).
 
 All of this module's variables are defined in [variables.tf](https://github.com/sourcegraph/terraform-aws-executors/blob/v7.6.0/variables.tf).
+
+This example uses the root module defaults: a `c5n.metal` instance, up to 18 concurrent jobs, and per-job limits of 4 vCPUs, 12 GB of memory, and 20 GB of Firecracker disk space. `c5n.metal` is not required: you can use any amd64 instance that meets [Sourcegraph's KVM requirements](https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#dependencies), including supported non-metal AWS instances with nested virtualization enabled. Review the [executor sizing guidance](../../README.md#sizing-executor-instances) and adjust these values for your workload before deploying.

--- a/modules/executors/README.md
+++ b/modules/executors/README.md
@@ -11,3 +11,23 @@ This module provides the resources to provision [Sourcegraph executor](https://d
 This module does **not** automatically create networking or Docker mirror resources. The `vpc_id`, `subnet_id`, and `docker_registry_mirror` variables must be supplied explicitly with resources that have been previously created.
 
 This module is often used with the sibling modules that create [networking](https://registry.terraform.io/modules/sourcegraph/executors/aws/7.6.0/submodules/networking) and [Docker mirror](https://registry.terraform.io/modules/sourcegraph/executors/aws/7.6.0/submodules/docker-mirror) resources which can be shared by multiple instances of the executor module (listening to different queues or being deployed in a different environment).
+
+## Sizing executor instances
+
+`machine_type` selects the EC2 instance type and defaults to `c5n.metal` (72 vCPUs and 192 GiB of memory). `c5n.metal` is not required: you can use any instance that meets the isolation requirements below. Choose its size based on per-job resources, concurrency, and measured workload, as described in Sourcegraph's [executor capacity guidance](https://sourcegraph.com/docs/self-hosted/executors/resource-sizing).
+
+Sourcegraph's [binary deployment requirements](https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#dependencies) specify that, when Firecracker isolation is enabled, the instance must be amd64 and expose KVM at `/dev/kvm`. You can use a bare-metal instance or a non-metal instance with AWS nested virtualization enabled. As of August 2026, [AWS supports nested virtualization](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html#nested-virtualization-considerations) on the following Intel-based families: `C8i`, `M8i`, `R8i`, `C8id`, `M8id`, `R8id`, `C8i-flex`, `M8i-flex`, `R8i-flex`, `X8i`, `C7i`, `M7i`, `R7i`, `C7i-flex`, `M7i-flex`, and `I7i`. Nitro-based instances outside this list are not necessarily supported.
+
+[AWS requires nested virtualization to be enabled](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-ec2-nested-virtualization.html#nested-virtualization-launch-new-instance) as an EC2 CPU option when launching a supported non-metal instance; selecting the instance type alone does not enable it. If Firecracker isolation is disabled, KVM is not required.
+
+Each instance can run up to `maximum_num_jobs` jobs concurrently (18 by default), with per-job limits set by `job_num_cpus` (4 by default) and `job_memory` (`12GB` by default).
+
+Following Sourcegraph's [capacity calculation](https://sourcegraph.com/docs/self-hosted/executors/resource-sizing#calculate-capacity-for-concurrent-jobs), estimate the maximum concurrent demand as:
+
+- vCPUs: `maximum_num_jobs * job_num_cpus`
+- memory: `maximum_num_jobs * job_memory`
+- Firecracker disk: `maximum_num_jobs * firecracker_disk_space`
+
+These products represent worst-case demand rather than reserved capacity. The defaults allow overcommit because jobs are not expected to reach every limit simultaneously. Choose a larger instance, or reduce concurrency and per-job limits, if that assumption does not fit your workload. Also leave capacity for the operating system, executor process, VM images, job workspaces, and other overhead. `boot_disk_size` defaults to 500 GB when this submodule is used directly.
+
+When `use_firecracker` is enabled (the default), `job_num_cpus` must be either `1` or an even number. `firecracker_disk_space` must be a valid data size such as `20GB` (the default). Before deploying, verify that the selected instance exposes `/dev/kvm`.

--- a/modules/executors/variables.tf
+++ b/modules/executors/variables.tf
@@ -23,7 +23,7 @@ variable "machine_image" {
 variable "machine_type" {
   type        = string
   default     = "c5n.metal" // 72 vCPU, 192GB
-  description = "Executor node machine type."
+  description = "Executor EC2 instance type. When using Firecracker, use either an amd64 bare-metal instance or an amd64 non-metal instance that has nested virtualization enabled and /dev/kvm available. See [Sourcegraph's executor requirements](https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#dependencies)."
 }
 
 variable "ami_version" {

--- a/variables.tf
+++ b/variables.tf
@@ -60,7 +60,7 @@ variable "executor_machine_image" {
 variable "executor_machine_type" {
   type        = string
   default     = "c5n.metal" // 72 vCPU, 192GB
-  description = "Executor node machine type."
+  description = "Executor EC2 instance type. When using Firecracker, use either an amd64 bare-metal instance or an amd64 non-metal instance that has nested virtualization enabled and /dev/kvm available. See [Sourcegraph's executor requirements](https://sourcegraph.com/docs/self-hosted/executors/deploy-executors-binary#dependencies)."
 }
 
 variable "executor_boot_disk_size" {


### PR DESCRIPTION
- explain how concurrency and per-job limits affect executor instance sizing
- clarify that the c5n.metal default is retained for compatibility, not a general recommendation
- document supported non-metal AWS nested-virtualization families and KVM requirements
- link the recommendations to official Sourcegraph and AWS documentation
- improve the root and submodule machine type variable descriptions

Closes SVC-2551

## Testing

- `git diff --check`